### PR TITLE
Remove forced use of default CMAKE_CXX_COMPILER

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,10 +29,11 @@ fi
 
 # Change the copyright date at the top of any text files
 for file in $files; do
+    [[ -L $file ]] && continue
     echo "Processing copyright dates in $file"
     if [[ -e $file ]]; then
         /usr/bin/perl -pi -e 'INIT { exit 1 if !-f $ARGV[0] || -B $ARGV[0]; $year = (localtime)[5] + 1900 }
-            s/^([*\/#[:space:]]*)Copyright\s+(?:\(C\)\s*)?(\d+)(?:\s*-\s*\d+)?/qq($1Copyright $2@{[$year != $2 ? "-$year" : ""]})/ie
+            s/^([*\/#\/"*[:space:]]*)Copyright\s+(?:\(C\)\s*)?(\d+)(?:\s*-\s*\d+)?\s(Advanced\s*Micro\s*Devices)/qq($1Copyright (c) $2@{[$year != $2 ? "-$year" : ""]} $3)/ie
             if $. < 10' "$file" && git add -u "$file"
     fi
 done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,12 +26,6 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-if(NOT CMAKE_CXX_COMPILER)
-  set(CMAKE_CXX_COMPILER "/opt/rocm/bin/hipcc" CACHE STRING
-    "Choose the type of compiler to build: Default point to hipcc"
-    FORCE)
-endif()
-
 # NOTE: This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
 if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright 2023 Advanced Micro Devices, Inc.
+ # Copyright (c) 2023 Advanced Micro Devices, Inc.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright (c) 2023 Advanced Micro Devices, Inc.
+ # Copyright 2023 Advanced Micro Devices, Inc.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,23 @@ rocm_package_add_dependencies("composable_kernel >= 1.0.0" COMPONENT tests)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+# Create test executables and deploy
+function(add_hiptensor_component COMPONENT_NAME COMPONENT_SOURCES)
+
+    message( STATUS "adding hiptensor component: ${COMPONENT_NAME}")
+
+    # Ensure that all the sources are captured
+    list(APPEND COMPONENT_SOURCES ${ARGN})
+
+    # Build components as object files.
+    # Make sure they have -fPIC and that they inherit the hip::device environment
+    # so that they build for all archs in AMDGPU_TARGETS
+    add_library(${COMPONENT_NAME} OBJECT ${COMPONENT_SOURCES})
+    set_target_properties(${COMPONENT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_link_libraries(${COMPONENT_NAME} PRIVATE hip::device)
+
+endfunction()
+
 include_directories(BEFORE
     ${PROJECT_SOURCE_DIR}/library/include
     ${PROJECT_SOURCE_DIR}/library/src/include
@@ -48,9 +65,7 @@ set(HIPTENSOR_CORE_SOURCES
    ${CMAKE_CURRENT_SOURCE_DIR}/handle.cpp
 )
 
-add_library(hiptensor_core OBJECT ${HIPTENSOR_CORE_SOURCES})
-target_compile_features(hiptensor_core PUBLIC)
-set_target_properties(hiptensor_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+add_hiptensor_component(hiptensor_core ${HIPTENSOR_CORE_SOURCES})
 
 # Generate shared lib
 add_library(hiptensor SHARED

--- a/library/src/contraction/CMakeLists.txt
+++ b/library/src/contraction/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright 2023 Advanced Micro Devices, Inc.
+ # Copyright (c) 2023 Advanced Micro Devices, Inc.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal

--- a/library/src/contraction/CMakeLists.txt
+++ b/library/src/contraction/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright (c) 2023 Advanced Micro Devices, Inc.
+ # Copyright 2023 Advanced Micro Devices, Inc.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal
@@ -38,8 +38,7 @@ set(HIPTENSOR_CONTRACTION_SOURCES
    ${CMAKE_CURRENT_SOURCE_DIR}/contraction_solution.cpp
 )
 
-add_library(hiptensor_contraction OBJECT ${HIPTENSOR_CONTRACTION_SOURCES})
+add_hiptensor_component(hiptensor_contraction ${HIPTENSOR_CONTRACTION_SOURCES})
 target_include_directories(hiptensor_contraction PRIVATE ${composable_kernel_INCLUDES})
-set_target_properties(hiptensor_contraction PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_subdirectory(device)

--- a/library/src/contraction/device/CMakeLists.txt
+++ b/library/src/contraction/device/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright 2023 Advanced Micro Devices, Inc.
+ # Copyright (c) 2023 Advanced Micro Devices, Inc.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal

--- a/library/src/contraction/device/CMakeLists.txt
+++ b/library/src/contraction/device/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright (c) 2023 Advanced Micro Devices, Inc.
+ # Copyright 2023 Advanced Micro Devices, Inc.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,5 @@ set(CK_CONTRACTION_INSTANCE_SOURCES
    ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mnn_instance.cpp
 )
 
-add_library(hiptensor_contraction_instances OBJECT ${CK_CONTRACTION_INSTANCE_SOURCES})
+add_hiptensor_component(hiptensor_contraction_instances ${CK_CONTRACTION_INSTANCE_SOURCES})
 target_include_directories(hiptensor_contraction_instances PRIVATE ${composable_kernel_INCLUDES})
-set_target_properties(hiptensor_contraction_instances PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
- Allows the user to specify compiler using symbols CC and CXX
- Ensure that the AMDGPU_TARGETS symbol from hip::device is used when building library code
- Fixes the copyright symbol from .githooks/pre-commit