### PR TITLE
Add Doxygen warnings as errors

### DIFF
--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -765,6 +765,15 @@ WARN_FORMAT            = "$file:$line: $text"
 
 WARN_LOGFILE           =
 
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
+# a warning is encountered. If the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS
+# then doxygen will continue running as if WARN_AS_ERROR tag is set to NO, but
+# at the end of the doxygen process doxygen will return with a non-zero status.
+# Possible values are: NO, YES and FAIL_ON_WARNINGS.
+# The default value is: NO.
+
+WARN_AS_ERROR          = YES
+
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------

--- a/library/include/hiptensor/hiptensor.hpp
+++ b/library/include/hiptensor/hiptensor.hpp
@@ -298,7 +298,7 @@ hiptensorStatus_t hiptensorLoggerSetLevel(hiptensorLogLevel_t level);
  * \brief User-specified logging mask. A mask may be a binary OR combination of
  * several log levels together. Logs in other contexts will not be recorded.
  *
- * \param[in] level This parameter is the logging mask to be enforced.
+ * \param[in] mask This parameter is the logging mask to be enforced.
  * \retval HIPTENSOR_STATUS_SUCCESS if the operation completed successfully.
  * \retval HIPTENSOR_STATUS_INVALID_VALUE if the given log mask is invalid.
  */

--- a/library/src/contraction/contraction_solution_registry.cpp
+++ b/library/src/contraction/contraction_solution_registry.cpp
@@ -33,6 +33,7 @@ namespace hiptensor
     /// Class ContractionSolutionRegistry::Query ///
     ////////////////////////////////////////////////
 
+    // @cond
     ContractionSolutionRegistry::Query::Query(Query const& other)
         : mAllSolutions(other.mAllSolutions)
         , mSolutionHash(other.mSolutionHash)
@@ -289,5 +290,6 @@ namespace hiptensor
     {
         return mSolutionStorage.size();
     }
+    // @endcond
 
 } // namespace hiptensor

--- a/library/src/contraction/contraction_solution_registry.hpp
+++ b/library/src/contraction/contraction_solution_registry.hpp
@@ -37,6 +37,7 @@
 
 namespace hiptensor
 {
+    // @cond
     class ContractionSolution;
 
     class ContractionSolutionRegistry
@@ -165,6 +166,7 @@ namespace hiptensor
         std::vector<std::unique_ptr<ContractionSolution>> mSolutionStorage;
         Query                                             mSolutionQuery;
     };
+    // @endcond
 
 } // namespace hiptensor
 


### PR DESCRIPTION
- There are bugs in Doxygen 1.8.13 which is used by readthedocs
  - Skip code to avoid Doxygen errors