### PR TITLE
Add gfx940 target for f32/f64 types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ include(ROCMInstallSymlinks)
 include(CheckCXXCompilerFlag)
 
 rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-  TARGETS "gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+" )
+  TARGETS "gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940:xnack-;gfx940:xnack+" )
 
 # Variable AMDGPU_TARGET must be a cached variable and must be specified before calling find_package(hip)
 # This is because hip-config.cmake sets --offload-arch via AMDGPU_TARGET cached variable __after__ setting

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ include(ROCMInstallSymlinks)
 include(CheckCXXCompilerFlag)
 
 rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-  TARGETS "gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940:xnack-;gfx940:xnack+" )
+  TARGETS "gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940;gfx941;gfx942" )
 
 # Variable AMDGPU_TARGET must be a cached variable and must be specified before calling find_package(hip)
 # This is because hip-config.cmake sets --offload-arch via AMDGPU_TARGET cached variable __after__ setting

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 hiptensor is AMD's C++ library for accelerating tensor primitives based on the composable kernel library, through general purpose kernel languages, like HIP C++.
 
 ## GPU Support
-* AMD CDNA class GPU featuring matrix core support: gfx908, gfx90a as 'gfx9'
+* AMD CDNA class GPU featuring matrix core support: gfx908, gfx90a as 'gfx9', gfx940
 
-`Note: Double precision FP64 datatype support requires gfx90a`
+`Note: Double precision FP64 datatype support requires gfx90a or gfx940`
 
 ## Minimum Software Requirements
 * ROCm stack minimum version 5.7
@@ -56,7 +56,7 @@ git push origin <new_branch>
 ### Project options
 |Option|Description|Default Value|
 |---|---|---|
-|AMDGPU_TARGETS|Build code for specific GPU target(s)|gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+|
+|AMDGPU_TARGETS|Build code for specific GPU target(s)|gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940:xnack-;gfx940:xnack+|
 |HIPTENSOR_BUILD_TESTS|Build Tests|ON|
 |HIPTENSOR_BUILD_SAMPLES|Build Samples|ON|
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 hiptensor is AMD's C++ library for accelerating tensor primitives based on the composable kernel library, through general purpose kernel languages, like HIP C++.
 
 ## GPU Support
-* AMD CDNA class GPU featuring matrix core support: gfx908, gfx90a, gfx940 as 'gfx9'
+* AMD CDNA class GPU featuring matrix core support: gfx908, gfx90a, gfx940, gfx941, gfx942 as 'gfx9'
 
-`Note: Double precision FP64 datatype support requires gfx90a or gfx940`
+`Note: Double precision FP64 datatype support requires gfx90a, gfx940, gfx941 or gfx942`
 
 ## Minimum Software Requirements
 * ROCm stack minimum version 5.7
@@ -56,7 +56,7 @@ git push origin <new_branch>
 ### Project options
 |Option|Description|Default Value|
 |---|---|---|
-|AMDGPU_TARGETS|Build code for specific GPU target(s)|gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940:xnack-;gfx940:xnack+|
+|AMDGPU_TARGETS|Build code for specific GPU target(s)|gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940;gfx941;gfx942|
 |HIPTENSOR_BUILD_TESTS|Build Tests|ON|
 |HIPTENSOR_BUILD_SAMPLES|Build Samples|ON|
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 hiptensor is AMD's C++ library for accelerating tensor primitives based on the composable kernel library, through general purpose kernel languages, like HIP C++.
 
 ## GPU Support
-* AMD CDNA class GPU featuring matrix core support: gfx908, gfx90a as 'gfx9', gfx940
+* AMD CDNA class GPU featuring matrix core support: gfx908, gfx90a, gfx940 as 'gfx9'
 
 `Note: Double precision FP64 datatype support requires gfx90a or gfx940`
 

--- a/docs/Linux_Install_Guide.rst
+++ b/docs/Linux_Install_Guide.rst
@@ -38,9 +38,9 @@ As a general rule, 8GB of system memory is required for a full hipTensor build. 
 
 GPU Support
 ^^^^^^^^^^^
-AMD CDNA class GPU featuring matrix core support: gfx908, gfx90a as 'gfx9'
+AMD CDNA class GPU featuring matrix core support: gfx908, gfx90a, gfx940, gfx941, gfx942 as 'gfx9'
 
-`Note: Double precision FP64 datatype support requires gfx90a`
+`Note: Double precision FP64 datatype support requires gfx90a, gfx940, gfx941 or gfx942`
 
 Download hipTensor
 ^^^^^^^^^^^^^^^^^^
@@ -84,15 +84,15 @@ Below are the project options available to build hipTensor library with/without 
 .. tabularcolumns::
    |C|C|C|
 
-+------------------------------+-------------------------------------+-------------------------------------------+
-|Option                        |Description                          |Default Value                              |
-+==============================+=====================================+===========================================+
-|AMDGPU_TARGETS                |Build code for specific GPU target(s)|gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+  |
-+------------------------------+-------------------------------------+-------------------------------------------+
-|HIPTENSOR_BUILD_TESTS         |Build Tests                          |ON                                         |
-+------------------------------+-------------------------------------+-------------------------------------------+
-|HIPTENSOR_BUILD_SAMPLES       |Build Samples                        |ON                                         |
-+------------------------------+-------------------------------------+-------------------------------------------+
++------------------------------+-------------------------------------+----------------------------------------------------------------+
+|Option                        |Description                          |Default Value                                                   |
++==============================+=====================================+================================================================+
+|AMDGPU_TARGETS                |Build code for specific GPU target(s)|gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940;gfx941;gfx942  |
++------------------------------+-------------------------------------+----------------------------------------------------------------+
+|HIPTENSOR_BUILD_TESTS         |Build Tests                          |ON                                                              |
++------------------------------+-------------------------------------+----------------------------------------------------------------+
+|HIPTENSOR_BUILD_SAMPLES       |Build Samples                        |ON                                                              |
++------------------------------+-------------------------------------+----------------------------------------------------------------+
 
 
 Build only library

--- a/library/src/hip_device.cpp
+++ b/library/src/hip_device.cpp
@@ -52,6 +52,10 @@ namespace hiptensor
         {
             mGcnArch = hipGcnArch_t::GFX90A;
         }
+        else if(deviceName.find("gfx940") != std::string::npos)
+        {
+            mGcnArch = hipGcnArch_t::GFX940;
+        }
 
         switch(mProps.warpSize)
         {
@@ -107,7 +111,7 @@ namespace hiptensor
 
     bool HipDevice::supportsF64() const
     {
-        return (mGcnArch == HipDevice::hipGcnArch_t::GFX90A);
+        return (mGcnArch == HipDevice::hipGcnArch_t::GFX90A || mGcnArch == HipDevice::hipGcnArch_t::GFX940);
     }
 
 } // namespace hiptensor

--- a/library/src/hip_device.cpp
+++ b/library/src/hip_device.cpp
@@ -56,6 +56,14 @@ namespace hiptensor
         {
             mGcnArch = hipGcnArch_t::GFX940;
         }
+        else if(deviceName.find("gfx941") != std::string::npos)
+        {
+            mGcnArch = hipGcnArch_t::GFX941;
+        }
+        else if(deviceName.find("gfx942") != std::string::npos)
+        {
+            mGcnArch = hipGcnArch_t::GFX942;
+        }
 
         switch(mProps.warpSize)
         {
@@ -111,7 +119,8 @@ namespace hiptensor
 
     bool HipDevice::supportsF64() const
     {
-        return (mGcnArch == HipDevice::hipGcnArch_t::GFX90A || mGcnArch == HipDevice::hipGcnArch_t::GFX940);
+        return (mGcnArch == HipDevice::hipGcnArch_t::GFX90A || mGcnArch == HipDevice::hipGcnArch_t::GFX940 ||
+                mGcnArch == HipDevice::hipGcnArch_t::GFX941 || mGcnArch == HipDevice::hipGcnArch_t::GFX942);
     }
 
 } // namespace hiptensor

--- a/library/src/include/hip_device.hpp
+++ b/library/src/include/hip_device.hpp
@@ -39,6 +39,8 @@ namespace hiptensor
             GFX908           = 0x908,
             GFX90A           = 0x90A,
             GFX940           = 0x940,
+            GFX941           = 0x941,
+            GFX942           = 0x942,
             UNSUPPORTED_ARCH = 0x0,
         };
 

--- a/library/src/include/hip_device.hpp
+++ b/library/src/include/hip_device.hpp
@@ -38,6 +38,7 @@ namespace hiptensor
         {
             GFX908           = 0x908,
             GFX90A           = 0x90A,
+            GFX940           = 0x940,
             UNSUPPORTED_ARCH = 0x0,
         };
 

--- a/samples/01_contraction/common.hpp
+++ b/samples/01_contraction/common.hpp
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef HIPTENSOR_SAMPLES_CONTRACTION_COMMON_HPP
+#define HIPTENSOR_SAMPLES_CONTRACTION_COMMON_HPP
+
+#define MAX_ELEMENTS_PRINT_COUNT 512
+
+#define HIPTENSOR_FREE_DEVICE(ptr)     \
+    if(ptr != nullptr)                 \
+    {                                  \
+        CHECK_HIP_ERROR(hipFree(ptr)); \
+    }
+
+#define HIPTENSOR_FREE_HOST(ptr) \
+    if(ptr != nullptr)           \
+    {                            \
+        free(ptr);               \
+    }
+
+inline bool isF32Supported()
+{
+    hipDevice_t     mHandle;
+    hipDeviceProp_t mProps;
+
+    CHECK_HIP_ERROR(hipGetDevice(&mHandle));
+    CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return (deviceName.find("gfx908") != std::string::npos)
+           || (deviceName.find("gfx90a") != std::string::npos)
+           || (deviceName.find("gfx940") != std::string::npos);
+}
+
+inline bool isF64Supported()
+{
+    hipDevice_t     mHandle;
+    hipDeviceProp_t mProps;
+
+    CHECK_HIP_ERROR(hipGetDevice(&mHandle));
+    CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return (deviceName.find("gfx90a") != std::string::npos)
+           || (deviceName.find("gfx940") != std::string::npos);
+}
+
+#endif // HIPTENSOR_SAMPLES_CONTRACTION_COMMON_HPP

--- a/samples/01_contraction/common.hpp
+++ b/samples/01_contraction/common.hpp
@@ -53,7 +53,9 @@ inline bool isF32Supported()
 
     return (deviceName.find("gfx908") != std::string::npos)
            || (deviceName.find("gfx90a") != std::string::npos)
-           || (deviceName.find("gfx940") != std::string::npos);
+           || (deviceName.find("gfx940") != std::string::npos)
+           || (deviceName.find("gfx941") != std::string::npos)
+           || (deviceName.find("gfx942") != std::string::npos);
 }
 
 inline bool isF64Supported()
@@ -67,7 +69,9 @@ inline bool isF64Supported()
     std::string deviceName(mProps.gcnArchName);
 
     return (deviceName.find("gfx90a") != std::string::npos)
-           || (deviceName.find("gfx940") != std::string::npos);
+           || (deviceName.find("gfx940") != std::string::npos)
+           || (deviceName.find("gfx941") != std::string::npos)
+           || (deviceName.find("gfx942") != std::string::npos);
 }
 
 #endif // HIPTENSOR_SAMPLES_CONTRACTION_COMMON_HPP

--- a/samples/01_contraction/simple_bilinear_contraction_f32.cpp
+++ b/samples/01_contraction/simple_bilinear_contraction_f32.cpp
@@ -58,7 +58,8 @@ inline bool isF32Supported()
     std::string deviceName(mProps.gcnArchName);
 
     return (deviceName.find("gfx908") != std::string::npos)
-           || (deviceName.find("gfx90a") != std::string::npos);
+            || (deviceName.find("gfx90a") != std::string::npos)
+            || (deviceName.find("gfx940") != std::string::npos);
 }
 
 int main(int argc, char* argv[])

--- a/samples/01_contraction/simple_bilinear_contraction_f32.cpp
+++ b/samples/01_contraction/simple_bilinear_contraction_f32.cpp
@@ -33,34 +33,7 @@
 #include <numeric>
 #include <unordered_map>
 
-#define MAX_ELEMENTS_PRINT_COUNT 512
-
-#define HIPTENSOR_FREE_DEVICE(ptr)     \
-    if(ptr != nullptr)                 \
-    {                                  \
-        CHECK_HIP_ERROR(hipFree(ptr)); \
-    }
-
-#define HIPTENSOR_FREE_HOST(ptr) \
-    if(ptr != nullptr)           \
-    {                            \
-        free(ptr);               \
-    }
-
-inline bool isF32Supported()
-{
-    hipDevice_t     mHandle;
-    hipDeviceProp_t mProps;
-
-    CHECK_HIP_ERROR(hipGetDevice(&mHandle));
-    CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
-
-    std::string deviceName(mProps.gcnArchName);
-
-    return (deviceName.find("gfx908") != std::string::npos)
-            || (deviceName.find("gfx90a") != std::string::npos)
-            || (deviceName.find("gfx940") != std::string::npos);
-}
+#include "common.hpp"
 
 int main(int argc, char* argv[])
 {

--- a/samples/01_contraction/simple_scale_contraction_f32.cpp
+++ b/samples/01_contraction/simple_scale_contraction_f32.cpp
@@ -32,22 +32,19 @@
 #include <numeric>
 #include <unordered_map>
 
-#define MAX_ELEMENTS_PRINT_COUNT 512
-
-#define HIPTENSOR_FREE_DEVICE(ptr)     \
-    if(ptr != nullptr)                 \
-    {                                  \
-        CHECK_HIP_ERROR(hipFree(ptr)); \
-    }
-
-#define HIPTENSOR_FREE_HOST(ptr) \
-    if(ptr != nullptr)           \
-    {                            \
-        free(ptr);               \
-    }
+#include "common.hpp"
 
 int main(int argc, char* argv[])
 {
+   /***************************************
+   * Check device support                 *
+   **************************************/
+    if(!isF32Supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
     typedef float ADataType;
     typedef float BDataType;
     typedef float DDataType;

--- a/test/01_contraction/common.hpp
+++ b/test/01_contraction/common.hpp
@@ -66,7 +66,8 @@ inline bool isF32Supported()
     std::string deviceName(mProps.gcnArchName);
 
     return (deviceName.find("gfx908") != std::string::npos)
-           || (deviceName.find("gfx90a") != std::string::npos);
+           || (deviceName.find("gfx90a") != std::string::npos)
+           || (deviceName.find("gfx940") != std::string::npos);
 }
 
 inline bool isF64Supported()
@@ -79,7 +80,8 @@ inline bool isF64Supported()
 
     std::string deviceName(mProps.gcnArchName);
 
-    return (deviceName.find("gfx90a") != std::string::npos);
+    return (deviceName.find("gfx90a") != std::string::npos)
+           || (deviceName.find("gfx940") != std::string::npos);
 }
 
 template <typename intT1,

--- a/test/01_contraction/common.hpp
+++ b/test/01_contraction/common.hpp
@@ -67,7 +67,9 @@ inline bool isF32Supported()
 
     return (deviceName.find("gfx908") != std::string::npos)
            || (deviceName.find("gfx90a") != std::string::npos)
-           || (deviceName.find("gfx940") != std::string::npos);
+           || (deviceName.find("gfx940") != std::string::npos)
+           || (deviceName.find("gfx941") != std::string::npos)
+           || (deviceName.find("gfx942") != std::string::npos);
 }
 
 inline bool isF64Supported()
@@ -81,7 +83,9 @@ inline bool isF64Supported()
     std::string deviceName(mProps.gcnArchName);
 
     return (deviceName.find("gfx90a") != std::string::npos)
-           || (deviceName.find("gfx940") != std::string::npos);
+           || (deviceName.find("gfx940") != std::string::npos)
+           || (deviceName.find("gfx941") != std::string::npos)
+           || (deviceName.find("gfx942") != std::string::npos);
 }
 
 template <typename intT1,


### PR DESCRIPTION
Add gfx940 to the targets
Enable the existing datatypes support on the above target