### PR TITLE
Set RPath of test and sample executables correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 hiptensor_version.hpp
 hiptensor-version.hpp
 
+# Generated source file
+test/01_contraction/configs/*.hpp
+
 # Precompiled Headers
 *.gch
 *.pch

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -37,7 +37,7 @@ if( CMAKE_PROJECT_NAME STREQUAL "hiptensor" )
 
         # Sample must propagate the build interface includes to make sure
         # hiptensor includes are captured at runtime.
-        target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
+        target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
         target_include_directories(${BINARY_NAME} PRIVATE
                                 ${CMAKE_CURRENT_SOURCE_DIR}
                                 ${PROJECT_SOURCE_DIR}/library/include)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,7 +94,7 @@ function(add_hiptensor_test BINARY_NAME YAML_CONFIG_FILE TEST_SOURCES)
 
     # Test must propagate the build interface includes to make sure
     # hiptensor includes are captured at runtime.
-    target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor hiptensor_llvm gtest "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
+    target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor hiptensor_llvm gtest "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
 
     target_include_directories(${BINARY_NAME} PRIVATE
                                ${CMAKE_CURRENT_SOURCE_DIR}
@@ -142,7 +142,7 @@ function(add_hiptensor_unit_test BINARY_NAME FILE_NAME)
 
     # Test must propagate the build interface includes to make sure
     # hiptensor includes are captured at runtime.
-    target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor hiptensor_llvm "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
+    target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor hiptensor_llvm "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
     target_include_directories(${BINARY_NAME} PRIVATE
                                ${CMAKE_CURRENT_SOURCE_DIR}
                                ${PROJECT_SOURCE_DIR}/library/include

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,8 @@ if(NOT googletest_POPULATED)
   # Save the shared libs setting, then force to static libs
   set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
   set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build SHARED libraries" FORCE)
+  # Turn off gtest installation
+  set(INSTALL_GTEST OFF)
   # Add gtest targets as static libs
   add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
   # Restore shared libs setting


### PR DESCRIPTION
Test and sample executables cannot run without a proper RPath. 

Set it to `$ORIGIN/../${CMAKE_INSTALL_LIBDIR}`, i.e. "executable_path/../lib" 

This makes it work in both build folder and installation folder.

In build folder
```
congma13@x1000c7s5b0n0:~/work/forks/cong_hipTensor/build$ ctest 
Test project /home/congma13/work/forks/cong_hipTensor/build
    Start 1: logger_test
1/6 Test #1: logger_test ......................   Passed    0.03 sec
    Start 2: yaml_test
2/6 Test #2: yaml_test ........................   Passed    0.03 sec
    Start 3: bilinear_contraction_f32_test
3/6 Test #3: bilinear_contraction_f32_test ....   Passed    0.13 sec
    Start 4: bilinear_contraction_f64_test
4/6 Test #4: bilinear_contraction_f64_test ....   Passed    0.13 sec
    Start 5: scale_contraction_f32_test
5/6 Test #5: scale_contraction_f32_test .......   Passed    0.14 sec
    Start 6: scale_contraction_f64_test
6/6 Test #6: scale_contraction_f64_test .......   Passed    0.13 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =   0.63 sec

```

In installation folder
```
congma13@x1000c7s5b0n0:~/local/test/bin$ cd hiptensor/
congma13@x1000c7s5b0n0:~/local/test/bin/hiptensor$ ctest 
Test project /home/congma13/local/test/bin/hiptensor
    Start 1: logger_test
1/6 Test #1: logger_test ......................   Passed    0.03 sec
    Start 2: yaml_test
2/6 Test #2: yaml_test ........................   Passed    0.03 sec
    Start 3: bilinear_contraction_f32_test
3/6 Test #3: bilinear_contraction_f32_test ....   Passed    0.13 sec
    Start 4: bilinear_contraction_f64_test
4/6 Test #4: bilinear_contraction_f64_test ....   Passed    0.13 sec
    Start 5: scale_contraction_f32_test
5/6 Test #5: scale_contraction_f32_test .......   Passed    0.13 sec
    Start 6: scale_contraction_f64_test
6/6 Test #6: scale_contraction_f64_test .......   Passed    0.11 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =   0.59 sec
```