### PR TITLE
Add codeowners for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
-* @cgmillette @bragadeesh @mkarunan @dlangbe @congma13 @afanfa
+# Documentation files
+docs/* @saadrahim @LisaDelaney
+*.md  @saadrahim @LisaDelaney
+*.rst  @saadrahim @LisaDelaney
+# Header directory
+library/include/*  @saadrahim @LisaDelaney

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+* @cgmillette @bragadeesh @mkarunan @dlangbe @congma13 @afanfa
 # Documentation files
 docs/* @saadrahim @LisaDelaney
 *.md  @saadrahim @LisaDelaney


### PR DESCRIPTION
Adding code owners for documentation. Plan is to add mandatory reviews from this group of code owners to merge any documentation changes. The header directory is related to documentation and thus changes to that are also flagged for documentation review.