### PR TITLE
Bump cryptography from 40.0.2 to 41.0.4 in /docs/.sphinx

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -26,7 +26,7 @@ charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via sphinx-external-toc
-cryptography==40.0.2
+cryptography==41.0.4
     # via pyjwt
 deprecated==1.2.13
     # via pygithub
@@ -92,7 +92,7 @@ requests==2.28.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core>=0.24.0
+rocm-docs-core==0.24.2
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb


### PR DESCRIPTION
duplicated PR #116, will be merged into release-staging/rocm-rel-6.0