### PR TITLE
Link hip::device to hiptensor_llvm

### DIFF
--- a/test/llvm/CMakeLists.txt
+++ b/test/llvm/CMakeLists.txt
@@ -50,6 +50,7 @@ set(HIPTENSOR_LLVM_LIBS "-L${LLVM_LIBRARY_DIR}"
                         "-Wl,-rpath=${LLVM_LIBRARY_DIR}"
                         LLVMObjectYAML
                         LLVMSupport
+                        hip::device
                         )
 
 # Includes


### PR DESCRIPTION
hiptensor_llvm includes header files from hip. It cannot find these header files without linking to hip::device.

This issue did not appear on our dev machine since /opt/rocm/inlcude is in the implicit include paths of hipcc.

For some reasons, it is not on CI machine.

Added hip::device into hiptensor_llvm's private dependency list. The include dirs of hip::device will be used when building hiptensor_llvm.