### PR TITLE
Rocm rel 6.0/hiptensor build error

### DIFF
--- a/test/llvm/CMakeLists.txt
+++ b/test/llvm/CMakeLists.txt
@@ -50,6 +50,7 @@ set(HIPTENSOR_LLVM_LIBS "-L${LLVM_LIBRARY_DIR}"
                         "-Wl,-rpath=${LLVM_LIBRARY_DIR}"
                         LLVMObjectYAML
                         LLVMSupport
+                        hip::device
                         )
 
 # Includes


### PR DESCRIPTION
dup PR of #131, merge this into release-staging/rocm-rel-6.0