### PR TITLE
Add an API function hiptensorPermutation

### DIFF
--- a/library/include/hiptensor/hiptensor.hpp
+++ b/library/include/hiptensor/hiptensor.hpp
@@ -87,6 +87,35 @@ hiptensorStatus_t hiptensorInitTensorDescriptor(const hiptensorHandle_t*     han
 const char* hiptensorGetErrorString(const hiptensorStatus_t error);
 
 /**
+ * \brief Tensor permutation
+ *
+ * \param[in] handle Opaque handle holding hipTensor's library context.
+ * \param[in] alpha Scaling factor for A of the type typeScalar. Pointer to the host memory. If alpha is zero, A is not read and the corresponding unary operator is not applied.
+ * \param[in] A Multi-mode tensor of type typeA with nmodeA modes. Pointer to the GPU-accessible memory.
+ * \param[in] descA A descriptor that holds information about the data type, modes, and strides of A.
+ * \param[in] modeA Array of size descA->numModes that holds the names of the modes of A.
+ * \param[in,out] B Multi-mode tensor of type typeB with nmodeB modes. Pointer to the GPU-accessible memory.
+ * \param[in] descB A descriptor that holds information about the data type, modes, and strides of B.
+ * \param[in] modeB Array of size descB->numModes that holds the names of the modes of B
+ * \param[in] typeScalar data type of alpha
+ * \param[in] stream HIP stream to perform all operations.
+ * \retval HIPTENSOR_STATUS_NOT_SUPPORTED if the combination of data types or operations is not supported
+ * \retval HIPTENSOR_STATUS_INVALID_VALUE if tensor dimensions or modes have an illegal value
+ * \retval HIPTENSOR_STATUS_SUCCESS The operation completed successfully without error
+ * \retval HIPTENSOR_STATUS_NOT_INITIALIZED if the handle is not initialized.
+ */
+hiptensorStatus_t hiptensorPermutation(const hiptensorHandle_t*           handle,
+                                       const void*                        alpha,
+                                       const void*                        A,
+                                       const hiptensorTensorDescriptor_t* descA,
+                                       const int32_t                      modeA[],
+                                       void*                              B,
+                                       const hiptensorTensorDescriptor_t* descB,
+                                       const int32_t                      modeB[],
+                                       const hipDataType                  typeScalar,
+                                       const hipStream_t                  stream);
+
+/**
  * \brief Computes the alignment requirement for a given pointer and descriptor.
  * \param[in] handle Opaque handle holding hipTensor's library context.
  * \param[in] ptr Pointer to the respective tensor data.

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -54,6 +54,8 @@ include_directories(BEFORE
 
 # Generates hiptensor_contraction and hiptensor_contraction_instances
 add_subdirectory(contraction)
+# Generates hiptensor_permutation and hiptensor_permutation_instances
+add_subdirectory(permutation)
 
 # Core API code
 set(HIPTENSOR_CORE_SOURCES
@@ -69,10 +71,11 @@ add_hiptensor_component(hiptensor_core ${HIPTENSOR_CORE_SOURCES})
 
 # Generate shared lib
 add_library(hiptensor SHARED
-	    $<TARGET_OBJECTS:hiptensor_core>
-	    $<TARGET_OBJECTS:hiptensor_contraction>
-        $<TARGET_OBJECTS:hiptensor_contraction_instances>
-        )
+    $<TARGET_OBJECTS:hiptensor_core>
+    $<TARGET_OBJECTS:hiptensor_contraction>
+    $<TARGET_OBJECTS:hiptensor_contraction_instances>
+    $<TARGET_OBJECTS:hiptensor_permutation>
+    )
 
 add_library(hiptensor::hiptensor ALIAS hiptensor)
 

--- a/library/src/permutation/CMakeLists.txt
+++ b/library/src/permutation/CMakeLists.txt
@@ -1,0 +1,37 @@
+###############################################################################
+#
+# MIT License
+#
+# Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+# Don't link to consume ck instances, however will customize and create our own.
+# Make the ck includes visible so we can build instances.
+get_target_property(composable_kernel_INCLUDES composable_kernel::device_operations INTERFACE_INCLUDE_DIRECTORIES)
+
+set(HIPTENSOR_PERMUTATION_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/hiptensor_permutation.cpp
+    )
+
+add_hiptensor_component(hiptensor_permutation ${HIPTENSOR_PERMUTATION_SOURCES})
+target_include_directories(hiptensor_permutation PRIVATE ${composable_kernel_INCLUDES})
+

--- a/library/src/permutation/hiptensor_permutation.cpp
+++ b/library/src/permutation/hiptensor_permutation.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+#include <hiptensor/hiptensor.hpp>
+
+hiptensorStatus_t hiptensorPermutation(const hiptensorHandle_t*           handle,
+                                       const void*                        alpha,
+                                       const void*                        A,
+                                       const hiptensorTensorDescriptor_t* descA,
+                                       const int32_t                      modeA[],
+                                       void*                              B,
+                                       const hiptensorTensorDescriptor_t* descB,
+                                       const int32_t                      modeB[],
+                                       const hipDataType                  typeScalar,
+                                       const hipStream_t                  stream)
+{
+    return HIPTENSOR_STATUS_SUCCESS;
+}


### PR DESCRIPTION
hiptensorPermutation is a HIP implementation of cutensorPermutation.

Add CMakeLists.txt and function hiptensorPermutation. hiptensorPermutation is not implemented yet.