### PR TITLE
Use split CK libraries.

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -24,7 +24,7 @@
  #
  ###############################################################################
 
-find_package( composable_kernel 1.0.0 REQUIRED PATHS /opt/rocm /opt/rocm/ck $ENV{CK_DIR}/lib/cmake COMPONENTS device_operations )
+find_package( composable_kernel 1.0.0 REQUIRED PATHS /opt/rocm /opt/rocm/ck $ENV{CK_DIR}/lib/cmake COMPONENTS device_contraction_operations device_other_operations)
 rocm_package_add_dependencies("composable_kernel >= 1.0.0" COMPONENT tests)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/library/src/contraction/CMakeLists.txt
+++ b/library/src/contraction/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 # Don't link to consume ck instances, however will customize and create our own.
 # Make the ck includes visible so we can build instances.
-get_target_property(composable_kernel_INCLUDES composable_kernel::device_operations INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(composable_kernel_INCLUDES composable_kernel::device_contraction_operations INTERFACE_INCLUDE_DIRECTORIES)
 
 set(HIPTENSOR_CONTRACTION_SOURCES
    ${CMAKE_CURRENT_SOURCE_DIR}/hiptensor_contraction.cpp

--- a/library/src/contraction/CMakeLists.txt
+++ b/library/src/contraction/CMakeLists.txt
@@ -27,7 +27,7 @@
 # Don't link to consume ck instances, however will customize and create our own.
 # Make the ck includes visible so we can build instances.
 get_target_property(composable_kernel_INCLUDES composable_kernel::device_contraction_operations INTERFACE_INCLUDE_DIRECTORIES)
-
+get_target_property(composable_kernel_INCLUDES composable_kernel::device_other_operations INTERFACE_INCLUDE_DIRECTORIES)
 set(HIPTENSOR_CONTRACTION_SOURCES
    ${CMAKE_CURRENT_SOURCE_DIR}/hiptensor_contraction.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/contraction_cpu_reference.cpp

--- a/library/src/permutation/CMakeLists.txt
+++ b/library/src/permutation/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 # Don't link to consume ck instances, however will customize and create our own.
 # Make the ck includes visible so we can build instances.
-get_target_property(composable_kernel_INCLUDES composable_kernel::device_operations INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(composable_kernel_INCLUDES composable_kernel::device_other_operations INTERFACE_INCLUDE_DIRECTORIES)
 
 set(HIPTENSOR_PERMUTATION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/hiptensor_permutation.cpp

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
     add_compile_options(-std=c++17)
 
     # Requires linking installed composable kernel and hipTensor library
-    find_package(composable_kernel 1.0.0 REQUIRED PATHS /opt/rocm /opt/rocm/ck $ENV{CK_DIR}/lib/cmake COMPONENTS device_operations )
+    find_package(composable_kernel 1.0.0 REQUIRED PATHS /opt/rocm /opt/rocm/ck $ENV{CK_DIR}/lib/cmake COMPONENTS device_contraction_operations device_other_operations)
     find_package(hiptensor 0.2.0 REQUIRED PATHS /opt/rocm /opt/rocm/hiptensor $ENV{HIPTENSOR_DIR}/lib/cmake COMPONENTS hiptensor)
 
     # This helps cmake properly find hip-config.cmake


### PR DESCRIPTION
This change will allow using the split static libraries in CK, when instead of single libdevice_operations.a file, we can use a separate file for each operation type, e.g., device_contraction_operations, device_gemm_operations, etc.

This PR should be synchronized with the PR merge into CK and MIOpen.