### PR TITLE
Update llvm raw_fd_ostream usage to new interface

### DIFF
--- a/test/llvm/yaml_parser_impl.hpp
+++ b/test/llvm/yaml_parser_impl.hpp
@@ -27,6 +27,7 @@
 #ifndef HIPTENSOR_TEST_YAML_PARSER_IMPL_HPP
 #define HIPTENSOR_TEST_YAML_PARSER_IMPL_HPP
 
+#include <llvm/Support/FileSystem.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/YAMLParser.h>
 #include <llvm/Support/raw_ostream.h>
@@ -99,7 +100,7 @@ namespace hiptensor
     void YamlConfigLoader<ConfigT>::storeToFile(std::string const& filePath, ConfigT const& config)
     {
         std::error_code      ec;
-        llvm::raw_fd_ostream out(filePath, ec);
+        llvm::raw_fd_ostream out(filePath, ec, llvm::sys::fs::F_None);
 
         if(ec)
         {

--- a/test/llvm/yaml_parser_impl.hpp
+++ b/test/llvm/yaml_parser_impl.hpp
@@ -100,7 +100,7 @@ namespace hiptensor
     void YamlConfigLoader<ConfigT>::storeToFile(std::string const& filePath, ConfigT const& config)
     {
         std::error_code      ec;
-        llvm::raw_fd_ostream out(filePath, ec, llvm::sys::fs::F_None);
+        llvm::raw_fd_ostream out(filePath, ec, llvm::sys::fs::OF_None);
 
         if(ec)
         {


### PR DESCRIPTION
The constructor for raw_fd_ostream has changed with the new llvm version.

Adjusted to use default of  llvm::sys::fs::F_None flag.