### PR TITLE
Standardize documentation for ReadtheDocs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/docs/.sphinx" # Location of package manifests
+    directory: "/docs/sphinx" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -50,14 +50,3 @@ build*
 \#*\#
 *~
 *.log
-
-# documentation artifacts
-build/
-_build/
-_images/
-_static/
-_templates/
-_toc.yml
-docBin/
-_doxygen/
-.venv

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,11 +10,9 @@ formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/.sphinx/requirements.txt
+   - requirements: docs/sphinx/requirements.txt
 
 build:
-   os: ubuntu-20.04
+   os: ubuntu-22.04
    tools:
       python: "3.8"
-   apt_packages:
-     - "doxygen"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run the steps below to build documentation locally.
 ```shell
 cd docs
 
-pip3 install -r .sphinx/requirements.txt
+pip3 install -r sphinx/requirements.txt
 
 python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
 ```
@@ -98,21 +98,24 @@ After configuration, build with `cmake --build <build_dir> -- -j<nproc>`
 ### Logger tests
 
 Tests API implementation of logger verbosity and functionality.
-o <build_dir>/bin/logger_test
+
+* `<build_dir>/bin/logger_test`
 
 ## Running Contraction Tests
 
 ### Bilinear contraction tests
 
 Tests the API implementation of bilinear contraction algorithm with validation.
-o <build_dir>/bin/bilinear_contraction_f32_test
-o <build_dir>/bin/bilinear_contraction_f64_test
+
+* `<build_dir>/bin/bilinear_contraction_f32_test`
+* `<build_dir>/bin/bilinear_contraction_f64_test`
 
 ### Scale contraction tests
 
 Tests the API implementation of scale contraction algorithm with validation.
-o <build_dir>/bin/scale_contraction_f32_test
-o <build_dir>/bin/scale_contraction_f64_test
+
+* `<build_dir>/bin/scale_contraction_f32_test`
+* `<build_dir>/bin/scale_contraction_f64_test`
 
 ### Samples
 
@@ -121,12 +124,14 @@ These are stand-alone use-cases of the hipTensor contraction operations.
 ## F32 Bilinear contraction
 
 Demonstrates the API implementation of bilinear contraction operation without validation.
-o <build_dir>/bin/simple_contraction_bilinear_f32
+
+* `<build_dir>/bin/simple_contraction_bilinear_f32`
 
 ## F32 Scale contraction
 
 Demonstrates the API implementation of scale contraction operation without validation.
-o <build_dir>/bin/simple_contraction_scale_f32
+
+* `<build_dir>/bin/simple_contraction_scale_f32`
 
 ### Build Samples as external client
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,7 +1,5 @@
-.doxygen/docBin
-.sphinx/_toc.yml
-_build
-_doxygen
-_images
-_static
-_templates
+doxygen/html
+doxygen/xml
+sphinx/_toc.yml
+_build/
+_doxygen/

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,0 @@
-rocm-docs-core>=0.24.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,11 +29,31 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import re
+
 from rocm_docs import ROCmDocs
 
-docs_core = ROCmDocs("hipTensor Documentation")
-docs_core.run_doxygen()
+with open('../CMakeLists.txt', encoding='utf-8') as f:
+    match = re.search(r'.*\bset \( VERSION_STRING\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    if not match:
+        raise ValueError("VERSION not found!")
+    version_number = match[1]
+left_nav_title = f"hipTensor {version_number} Documentation"
+
+# for PDF output on Read the Docs
+project = "hipTensor Documentation"
+author = "Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
+
+external_toc_path = "./sphinx/_toc.yml"
+
+docs_core = ROCmDocs(left_nav_title)
+docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.setup()
+
+external_projects_current_project = "hiptensor"
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docBin
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -786,7 +786,8 @@ WARN_AS_ERROR          = YES
 
 INPUT                  = ../../library/include/hiptensor \
                          ../../library/include/hiptensor/internal \
-                         ../../library/src
+                         ../../library/src \
+                         ../../README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -965,7 +966,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ../README.md
+USE_MDFILE_AS_MAINPAGE = ../../README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. include:: ../LICENSE

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -8,3 +8,6 @@ subtrees:
     - file: API_Reference_Guide
     - file: Programmers_Guide
     - file: Contributors_Guide
+  - caption: About
+    entries:
+    - file: license

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,0 +1,1 @@
+rocm-docs-core==0.30.3

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -84,9 +84,7 @@ pygments==2.15.0
     #   pydata-sphinx-theme
     #   sphinx
 pyjwt[crypto]==2.6.0
-    # via
-    #   pygithub
-    #   pyjwt
+    # via pygithub
 pynacl==1.5.0
     # via pygithub
 pytz==2023.3.post1


### PR DESCRIPTION
Apply the following changes to project documentation for ReadtheDocs:

add version number to documentation left navigation bar and page title
add an "About" section with a license page
enable htmlzip, pdf, epub formats when publishing on Read the Docs
set pdf title, author, copyright, and version
rename .sphinx/.doxygen to sphinx/doxygen
remove docBin from URL
update rocm-docs-core dependency
update dependabot config

Relates to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/330