### PR TITLE
Update codeowners for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @cgmillette @bragadeesh @mkarunan @dlangbe @congma13 @afanfa
 # Documentation files
-docs/* @saadrahim @LisaDelaney
-*.md  @saadrahim @LisaDelaney
-*.rst  @saadrahim @LisaDelaney
+docs/* @ROCm/rocm-documentation
+*.md @ROCm/rocm-documentation
+*.rst @ROCm/rocm-documentation
 # Header directory
-library/include/*  @saadrahim @LisaDelaney
+library/include/* @ROCm/rocm-documentation @cgmillette @bragadeesh @mkarunan @dlangbe @congma13 @afanfa


### PR DESCRIPTION
Relates to https://github.com/ROCm/ROCm/issues/2833
Set documentation team as codeowners for documentation.
Goal is to make this group of code owners reviewers when merging documentation changes.
Header files included for doxygen docs.