### PR TITLE
Use compressed debug symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if( CMAKE_PROJECT_NAME STREQUAL "hiptensor" )
   option( HIPTENSOR_BUILD_TESTS "Build hiptensor tests" ON )
   option( HIPTENSOR_BUILD_SAMPLES "Build hiptensor samples" ON )
+  option( HIPTENSOR_BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)
   option( HIPTENSOR_DATA_LAYOUT_COL_MAJOR "Set hiptensor data layout to column major" ON )
 endif()
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -44,6 +44,12 @@ function(add_hiptensor_component COMPONENT_NAME COMPONENT_SOURCES)
     add_library(${COMPONENT_NAME} OBJECT ${COMPONENT_SOURCES})
     set_target_properties(${COMPONENT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(${COMPONENT_NAME} PRIVATE hip::device)
+    if(HIPTENSOR_BUILD_COMPRESSED_DBG)
+        target_compile_options(${COMPONENT_NAME} PRIVATE
+            "$<$<CONFIG:Debug>:-gz>"
+            "$<$<CONFIG:RelWithDebInfo>:-gz>"
+            )
+    endif()
 
 endfunction()
 
@@ -80,6 +86,12 @@ add_library(hiptensor SHARED
 add_library(hiptensor::hiptensor ALIAS hiptensor)
 
 target_compile_options(hiptensor PRIVATE ${CMAKE_CXX_FLAGS})
+if(HIPTENSOR_BUILD_COMPRESSED_DBG)
+    target_compile_options(hiptensor PRIVATE
+        "$<$<CONFIG:Debug>:-gz>"
+        "$<$<CONFIG:RelWithDebInfo>:-gz>"
+        )
+endif()
 
 set ( hiptensor_SOVERSION 0.1 )
 # nvcc can not recognize shared libraray file name with suffix other than *.so when linking.


### PR DESCRIPTION
The size of file will be greater than 2G in Debug and RelWithDebug mode.

The use of compressed debug symbols significantly reduces library size, avoiding the need to remove targets in the address sanitizer build. The non-address sanitizer debug builds didn't drop GPU targets, but shared the same library size problem as the address sanitizer build. This change will also fix those builds.