### PR TITLE
Read the yaml config file as non-text

### DIFF
--- a/test/00_unit/yaml_test.cpp
+++ b/test/00_unit/yaml_test.cpp
@@ -127,6 +127,10 @@ int main(int argc, char* argv[])
     hiptensor::YamlConfigLoader<hiptensor::ContractionTestParams>::storeToFile(tmpFile, yee);
     auto yee1
         = hiptensor::YamlConfigLoader<hiptensor::ContractionTestParams>::loadFromFile(tmpFile);
+    if(!yee1)
+    {
+        return -1;
+    }
 
     return 0;
 }

--- a/test/01_contraction/contraction_test_helpers.hpp
+++ b/test/01_contraction/contraction_test_helpers.hpp
@@ -47,13 +47,21 @@ auto inline load_config_helper()
 
     if(testOptions->usingDefaultConfig() && HIPTENSOR_TEST_YAML_BUNDLE)
     {
-        testParams = hiptensor::YamlConfigLoader<hiptensor::ContractionTestParams>::loadFromString(
+        auto params = hiptensor::YamlConfigLoader<hiptensor::ContractionTestParams>::loadFromString(
             HIPTENSOR_TEST_GET_YAML);
+        if(params)
+        {
+            testParams = params.value();
+        }
     }
     else
     {
-        testParams = hiptensor::YamlConfigLoader<hiptensor::ContractionTestParams>::loadFromFile(
+        auto params = hiptensor::YamlConfigLoader<hiptensor::ContractionTestParams>::loadFromFile(
             testOptions->inputFilename());
+        if(params)
+        {
+            testParams = params.value();
+        }
     }
 
     // testParams.printParams();

--- a/test/02_permutation/permutation_test_helpers.hpp
+++ b/test/02_permutation/permutation_test_helpers.hpp
@@ -47,13 +47,21 @@ auto inline load_config_helper()
 
     if(testOptions->usingDefaultConfig() && HIPTENSOR_TEST_YAML_BUNDLE)
     {
-        testParams = hiptensor::YamlConfigLoader<hiptensor::PermutationTestParams>::loadFromString(
+        auto params = hiptensor::YamlConfigLoader<hiptensor::PermutationTestParams>::loadFromString(
             HIPTENSOR_TEST_GET_YAML);
+        if(params)
+        {
+            testParams = params.value();
+        }
     }
     else
     {
-        testParams = hiptensor::YamlConfigLoader<hiptensor::PermutationTestParams>::loadFromFile(
+        auto params = hiptensor::YamlConfigLoader<hiptensor::PermutationTestParams>::loadFromFile(
             testOptions->inputFilename());
+        if(params)
+        {
+            testParams = params.value();
+        }
     }
 
     // testParams.printParams();

--- a/test/llvm/CMakeLists.txt
+++ b/test/llvm/CMakeLists.txt
@@ -35,8 +35,13 @@ find_library(LLVMSupport_LIBRARY NAMES LLVMSupport PATHS ${LLVM_LIBRARY_DIR})
 
 message(STATUS "adding hiptensor component: hiptensor_llvm")
 message(STATUS "LLVM_LIBRARY_DIR: ${LLVM_LIBRARY_DIR}")
+message(STATUS "LLVM_VERSION_MAJOR: ${LLVM_VERSION_MAJOR}")
 message(STATUS "LLVMObjectYAML_LIBRARY: ${LLVMObjectYAML_LIBRARY}")
 message(STATUS "LLVMSupport_LIBRARY: ${LLVMSupport_LIBRARY}")
+
+if(LLVM_VERSION_MAJOR VERSION_LESS "7")
+    message(FATAL_ERROR "LLVM_VERSION_MAJOR is ${LLVM_VERSION_MAJOR}. However, hipTensor only support LLVM 7.0 and above" )
+endif()
 
 if(NOT LLVMObjectYAML_LIBRARY)
     message(ERROR "Could not find library: LLVMObjectYAML" )

--- a/test/llvm/yaml_parser.hpp
+++ b/test/llvm/yaml_parser.hpp
@@ -27,6 +27,7 @@
 #ifndef HIPTENSOR_TEST_YAML_PARSER_HPP
 #define HIPTENSOR_TEST_YAML_PARSER_HPP
 
+#include <optional>
 #include <string>
 
 // Load / store interface for YAML test config files
@@ -35,9 +36,9 @@ namespace hiptensor
     template <typename ConfigT>
     struct YamlConfigLoader
     {
-        static ConfigT loadFromFile(std::string const& filePath);
-        static ConfigT loadFromString(std::string const& yaml = "");
-        static void    storeToFile(std::string const& filePath, ConfigT const& config);
+        static std::optional<ConfigT> loadFromFile(std::string const& filePath);
+        static std::optional<ConfigT> loadFromString(std::string const& yaml = "");
+        static void storeToFile(std::string const& filePath, ConfigT const& config);
     };
 }
 

--- a/test/llvm/yaml_parser_impl.hpp
+++ b/test/llvm/yaml_parser_impl.hpp
@@ -37,16 +37,16 @@ namespace hiptensor
 {
     template <typename ConfigT>
     /* static */
-    ConfigT YamlConfigLoader<ConfigT>::loadFromFile(std::string const& filePath)
+    std::optional<ConfigT> YamlConfigLoader<ConfigT>::loadFromFile(std::string const& filePath)
     {
         auto result = ConfigT{};
 
-        auto in = llvm::MemoryBuffer::getFile(filePath, true);
+        auto in = llvm::MemoryBuffer::getFile(filePath);
         if(std::error_code ec = in.getError())
         {
             llvm::errs() << "Cannot open file for reading: " << filePath << "\n";
             llvm::errs() << ec.message() << '\n';
-            return result;
+            return {};
         }
         else
         {
@@ -60,6 +60,7 @@ namespace hiptensor
         if(reader.error())
         {
             llvm::errs() << "Error reading input config: " << filePath << "\n";
+            return {};
         }
 
         return result;
@@ -67,7 +68,8 @@ namespace hiptensor
 
     template <typename ConfigT>
     /* static */
-    ConfigT YamlConfigLoader<ConfigT>::loadFromString(std::string const& yaml /*= ""*/)
+    std::optional<ConfigT>
+        YamlConfigLoader<ConfigT>::loadFromString(std::string const& yaml /*= ""*/)
     {
         auto result = ConfigT{};
 
@@ -75,7 +77,7 @@ namespace hiptensor
         if(in->getBufferSize() == 0)
         {
             llvm::errs() << "Cannot use empty string for MemoryBuffer\n";
-            return result;
+            return {};
         }
         else
         {
@@ -89,6 +91,7 @@ namespace hiptensor
         if(reader.error())
         {
             llvm::errs() << "Error reading input config: " << yaml << "\n";
+            return {};
         }
 
         return result;


### PR DESCRIPTION
There is no carriage linefeed at the end of each line of yaml file.

With the new llvm, should read the yaml file with default value `isText=false`