### PR TITLE
Only Searching for rocm-llvm-dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 -DNDEBUG") # clang++ failed to build the pro
 
 # Project options
 if( CMAKE_PROJECT_NAME STREQUAL "hiptensor" )
+  # The minimum version of LLVM hipTensor tests link to is 7.0. If the default LLVM found by CMake is less than 7.0, please specify a higher installed version
+  option( HIPTENSOR_LLVM_VERSION "Version of LLVM hipTensor test will use. It should greater than 6.0." "")
   option( HIPTENSOR_BUILD_TESTS "Build hiptensor tests" ON )
   option( HIPTENSOR_BUILD_SAMPLES "Build hiptensor samples" ON )
   option( HIPTENSOR_BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,6 @@ set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 -DNDEBUG") # clang++ failed to build the pro
 
 # Project options
 if( CMAKE_PROJECT_NAME STREQUAL "hiptensor" )
-  # The minimum version of LLVM hipTensor tests link to is 7.0. If the default LLVM found by CMake is less than 7.0, please specify a higher installed version
-  option( HIPTENSOR_LLVM_VERSION "Version of LLVM hipTensor test will use. It should greater than 6.0." "")
   option( HIPTENSOR_BUILD_TESTS "Build hiptensor tests" ON )
   option( HIPTENSOR_BUILD_SAMPLES "Build hiptensor samples" ON )
   option( HIPTENSOR_BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)

--- a/test/llvm/CMakeLists.txt
+++ b/test/llvm/CMakeLists.txt
@@ -25,7 +25,12 @@
  ###############################################################################
 
 # Find / configure LLVM
-find_package(LLVM ${HIPTENSOR_LLVM_VERSION} REQUIRED CONFIG)
+find_package(LLVM CONFIG HINTS ${ROCM_DIR}/../../..)
+
+if (NOT LLVM_DIR)
+    message(FATAL_ERROR "HipTensor requires LLVM version 7.0 or higher,"
+        " which cannot be found. Please install rocm-llvm-dev package first." )
+endif()
 
 # Required:
 # LLVMObjectYAML for YAML parsing
@@ -40,7 +45,12 @@ message(STATUS "LLVMObjectYAML_LIBRARY: ${LLVMObjectYAML_LIBRARY}")
 message(STATUS "LLVMSupport_LIBRARY: ${LLVMSupport_LIBRARY}")
 
 if(LLVM_VERSION_MAJOR VERSION_LESS "7")
-    message(FATAL_ERROR "LLVM_VERSION_MAJOR is ${LLVM_VERSION_MAJOR}. However, hipTensor only support LLVM 7.0 and above" )
+    message(FATAL_ERROR "The found LLVM version doesn't meet the minimum requirement.  Please "
+    "install version 7.0 or above.  It is recommend to install rocm-llvm-dev "
+    "(for ROCm versions higher than 6.0).  If you have installed multiple "
+    "versions of LLVM, you can specify which version to use by setting "
+    "LLVM_ROOT.  For example:\n"
+    "        -DLLVM_ROOT=/opt/rocm/llvm-7/lib")
 endif()
 
 if(NOT LLVMObjectYAML_LIBRARY)

--- a/test/llvm/CMakeLists.txt
+++ b/test/llvm/CMakeLists.txt
@@ -25,7 +25,7 @@
  ###############################################################################
 
 # Find / configure LLVM
-find_package(LLVM REQUIRED CONFIG)
+find_package(LLVM ${HIPTENSOR_LLVM_VERSION} REQUIRED CONFIG)
 
 # Required:
 # LLVMObjectYAML for YAML parsing


### PR DESCRIPTION
# Only searching for rocm-llvm-dev

HipTensor calls APIs of llvm package. But llvm is not installed with OS.

HipTensor should only use rocm-llvm-dev to reduce the 3rd party
dependency as rocm-llvm-dev is a part of rocm

Searching in /opt/rocm first

![image](https://github.com/ROCm/hipTensor/assets/142121551/de03fc4c-491c-4e0d-ac6e-9591d57b0b53)


No `rocm-llvm-dev`, searching in `/usr/lib`. And stop if the found LLVM is not 7.0 and above. 
![image](https://github.com/ROCm/hipTensor/assets/142121551/dc021ee8-b767-48c1-8f0b-04a922864b49)


---------------

# Require version of LLVM > 6.0

In yaml_parser_impl.hpp, we call `raw_fd_ostream(filePaht, ec)`. 

This signature was added in LLVM 7. 

Now in a staging 1 docker, LLVM 6 and 10 are installed. CMake script will choose LLVM 6 by default.

Then we will get a building error about `raw_fd_ostream`. 

To fix this issue, cmake script should only find LLVM >= 7.0.

Unfortunately, the following line does not work. 

`find_package(LLVM 7.0 REQUIRED CONFIG)`

Though the cmake docs states that `7.0` means all version >= 7.0. LLVM does not support it. 

For LLVM, `find_package(LLVM 7.0 REQUIRED CONFIG)` only match `7.0.*`

 To make it more flexible, added an option `HIPTENSOR_LLVM_VERSION` with default value "". It means camke will use the first LLVM it finds by default. If the LLVM < 7.0. User need to specify a higher installed version . 