### PR TITLE
Workaround for LLVM getFile() crash on SLES 15

### DIFF
--- a/test/llvm/yaml_parser_impl.hpp
+++ b/test/llvm/yaml_parser_impl.hpp
@@ -39,13 +39,10 @@ namespace hiptensor
     /* static */
     std::optional<ConfigT> YamlConfigLoader<ConfigT>::loadFromFile(std::string const& filePath)
     {
-        auto result = ConfigT{};
-
-        auto in = llvm::MemoryBuffer::getFile(filePath);
-        if(std::error_code ec = in.getError())
+        std::ifstream inputStream(filePath);
+        if(!inputStream)
         {
             llvm::errs() << "Cannot open file for reading: " << filePath << "\n";
-            llvm::errs() << ec.message() << '\n';
             return {};
         }
         else
@@ -53,17 +50,10 @@ namespace hiptensor
             llvm::outs() << "Opened file for reading: " << filePath << "\n";
         }
 
-        llvm::yaml::Input reader(**in);
+        std::string yamlString((std::istreambuf_iterator<char>(inputStream)),
+                               std::istreambuf_iterator<char>());
 
-        reader >> result;
-
-        if(reader.error())
-        {
-            llvm::errs() << "Error reading input config: " << filePath << "\n";
-            return {};
-        }
-
-        return result;
+        return loadFromString(yamlString);
     }
 
     template <typename ConfigT>
@@ -78,10 +68,6 @@ namespace hiptensor
         {
             llvm::errs() << "Cannot use empty string for MemoryBuffer\n";
             return {};
-        }
-        else
-        {
-            llvm::outs() << "Using yaml input string for buffer.\n";
         }
 
         llvm::yaml::Input reader(*in);


### PR DESCRIPTION
LLVM function getFile() crashes on SLES 15. As a workaround use loadFromString() to implement loadFromFile()