### PR TITLE
Make initArgs an private function

### DIFF
--- a/library/src/contraction/contraction_cpu_reference.cpp
+++ b/library/src/contraction/contraction_cpu_reference.cpp
@@ -69,29 +69,27 @@ hiptensorStatus_t hiptensorContractionReference(const hiptensorContractionPlan_t
     }
     else
     {
-        auto refCandidate = candidates.solutions().begin()->second;
-        if(refCandidate->initArgs(alpha,
-                                  A,
-                                  B,
-                                  beta,
-                                  C,
-                                  D,
-                                  a_ms_ks_lengths,
-                                  a_ms_ks_strides,
-                                  a_ms_ks_modes,
-                                  b_ns_ks_lengths,
-                                  b_ns_ks_strides,
-                                  b_ns_ks_modes,
-                                  c_ms_ns_lengths,
-                                  c_ms_ns_strides,
-                                  c_ms_ns_modes,
-                                  d_ms_ns_lengths,
-                                  d_ms_ns_strides,
-                                  d_ms_ns_modes,
-                                  workspace))
-        {
-            (*refCandidate)();
-        }
-        return HIPTENSOR_STATUS_SUCCESS;
+        auto refCandidate      = candidates.solutions().begin()->second;
+        auto [errorCode, time] = (*refCandidate)(alpha,
+                                                 A,
+                                                 B,
+                                                 beta,
+                                                 C,
+                                                 D,
+                                                 a_ms_ks_lengths,
+                                                 a_ms_ks_strides,
+                                                 a_ms_ks_modes,
+                                                 b_ns_ks_lengths,
+                                                 b_ns_ks_strides,
+                                                 b_ns_ks_modes,
+                                                 c_ms_ns_lengths,
+                                                 c_ms_ns_strides,
+                                                 c_ms_ns_modes,
+                                                 d_ms_ns_lengths,
+                                                 d_ms_ns_strides,
+                                                 d_ms_ns_modes,
+                                                 workspace,
+                                                 0);
+        return errorCode;
     }
 }

--- a/library/src/contraction/contraction_selection.cpp
+++ b/library/src/contraction/contraction_selection.cpp
@@ -116,29 +116,30 @@ namespace hiptensor
 
         for(auto* solution : candidates)
         {
-            if(solution->initArgs(&alpha,
-                                  A_d,
-                                  B_d,
-                                  &beta,
-                                  D_d,
-                                  E_d,
-                                  a_ms_ks_lengths,
-                                  a_ms_ks_strides,
-                                  a_ms_ks_modes,
-                                  b_ns_ks_lengths,
-                                  b_ns_ks_strides,
-                                  b_ns_ks_modes,
-                                  d_ms_ns_lengths,
-                                  d_ms_ns_strides,
-                                  d_ms_ns_modes,
-                                  e_ms_ns_lengths,
-                                  e_ms_ns_strides,
-                                  e_ms_ns_modes,
-                                  wspace)
-               && solution->workspaceSize() <= workspaceSize)
+            auto [errorCode, time] = (*solution)(&alpha,
+                                                 A_d,
+                                                 B_d,
+                                                 &beta,
+                                                 D_d,
+                                                 E_d,
+                                                 a_ms_ks_lengths,
+                                                 a_ms_ks_strides,
+                                                 a_ms_ks_modes,
+                                                 b_ns_ks_lengths,
+                                                 b_ns_ks_strides,
+                                                 b_ns_ks_modes,
+                                                 d_ms_ns_lengths,
+                                                 d_ms_ns_strides,
+                                                 d_ms_ns_modes,
+                                                 e_ms_ns_lengths,
+                                                 e_ms_ns_strides,
+                                                 e_ms_ns_modes,
+                                                 wspace,
+                                                 workspaceSize,
+                                                 StreamConfig{nullptr, true});
+            if(errorCode == HIPTENSOR_STATUS_SUCCESS && time > 0)
             {
                 // Make sure to time the kernels
-                auto    time = (*solution)(StreamConfig{nullptr, true});
                 int32_t m, n, k;
                 std::tie(m, n, k) = solution->problemDims();
                 auto flops        = std::size_t(2) * m * n * k;

--- a/library/src/contraction/contraction_solution.hpp
+++ b/library/src/contraction/contraction_solution.hpp
@@ -86,28 +86,28 @@ namespace hiptensor
                               void*                    workspacePtr)
             = 0;
 
-        float operator()(StreamConfig const& streamConfig = StreamConfig{});
-
-        float operator()(void const*              alpha,
-                         void const*              A,
-                         void const*              B,
-                         void const*              beta,
-                         void const*              D,
-                         void*                    E,
-                         std::vector<std::size_t> a_ms_ns_lengths,
-                         std::vector<std::size_t> a_ms_ks_strides,
-                         std::vector<int32_t>     a_ms_ks_modes,
-                         std::vector<std::size_t> b_ns_ks_lengths,
-                         std::vector<std::size_t> b_ns_ks_strides,
-                         std::vector<int32_t>     b_ns_ks_modes,
-                         std::vector<std::size_t> ds_ms_ns_lengths,
-                         std::vector<std::size_t> ds_ms_ns_strides,
-                         std::vector<int32_t>     ds_ms_ns_modes,
-                         std::vector<std::size_t> e_ms_ns_lengths,
-                         std::vector<std::size_t> e_ms_ns_strides,
-                         std::vector<int32_t>     e_ms_ns_modes,
-                         void*                    workspacePtr,
-                         StreamConfig const&      streamConfig = StreamConfig{});
+        std::tuple<hiptensorStatus_t, float> operator()(void const*              alpha,
+                                                        void const*              A,
+                                                        void const*              B,
+                                                        void const*              beta,
+                                                        void const*              D,
+                                                        void*                    E,
+                                                        std::vector<std::size_t> a_ms_ns_lengths,
+                                                        std::vector<std::size_t> a_ms_ks_strides,
+                                                        std::vector<int32_t>     a_ms_ks_modes,
+                                                        std::vector<std::size_t> b_ns_ks_lengths,
+                                                        std::vector<std::size_t> b_ns_ks_strides,
+                                                        std::vector<int32_t>     b_ns_ks_modes,
+                                                        std::vector<std::size_t> ds_ms_ns_lengths,
+                                                        std::vector<std::size_t> ds_ms_ns_strides,
+                                                        std::vector<int32_t>     ds_ms_ns_modes,
+                                                        std::vector<std::size_t> e_ms_ns_lengths,
+                                                        std::vector<std::size_t> e_ms_ns_strides,
+                                                        std::vector<int32_t>     e_ms_ns_modes,
+                                                        void*                    workspacePtr,
+                                                        unsigned long            workspaceSize,
+                                                        StreamConfig const&      streamConfig
+                                                        = StreamConfig{});
 
         /// Accessors
 


### PR DESCRIPTION
The internal device memory needs to be freed after invoking contraction. To make the interface easier to use, the three steps: `initArgs`, `Run`,
   `release` are moved into `operator()`.  Users will never forget to
   release the memory.