### PR TITLE
Update version number and changelog updates for ROCm 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,25 @@ Full documentation for hipTensor is available at [rocm.docs.amd.com/projects/hip
 
 ### Additions
 
+* Added support for tensor permutation of ranks of 2, 3, 4, 5 and 6
+* Added tests for tensor permutation of ranks of 2, 3, 4, 5 and 6
+* Added support for tensor contraction of M6N6K6: M, N, K up to rank 6
+* Added tests for tensor contraction of M6N6K6: M, N, K up to rank 6
+* Added new test YAML parsing to support sequential parameters ordering
+
 ### Changes
 
+* Documentation updates for installation, programmer's guide and API reference
+* Prefer amd-llvm-devel package before system LLVM library
+* Preferred compilers changed to CC=amdclang CXX=amdclang++
+* Updated actor-critic selection for new contraction kernel additions
+
 ### Fixes
+
+* Fixed LLVM parsing crash
+* Fixed memory consumption issue in complex kernels
+* Work-around implemented for compiler crash during debug build
+* Allow random modes ordering for tensor contractions
 
 ## hipTensor 1.2.0 for ROCm 6.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 Full documentation for hipTensor is available at [rocm.docs.amd.com/projects/hiptensor](https://rocm.docs.amd.com/projects/hipTensor/en/latest/index.html).
 
-## (Unreleased) hipTensor 1.1.0 for ROCm 6.0.0
+## (Unreleased) hipTensor 1.3.0 for ROCm 6.2.0
+
+### Additions
+
+### Changes
+
+### Fixes
+
+## hipTensor 1.2.0 for ROCm 6.1.0
+
+### Additions
+
+* API support for permutation of rank 4 tensors: f16 and f32
+* New datatype support in contractions of rank 4: f16, bf16, complex f32, complex f64
+* Added scale and bilinear contraction samples and tests for new supported data types
+* Added permutation samples and tests for f16, f32 types
+
+### Fixes
+
+* Fixed bug in contraction calculation with data type f32
+
+## hipTensor 1.1.0 for ROCm 6.0.0
 
 ### Additions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ if(HIPTENSOR_BUILD_SAMPLES)
 endif()
 
 # Versioning via rocm-cmake
-set ( VERSION_STRING "1.1.0" )
+set ( VERSION_STRING "1.3.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # configure a header file to pass the CMake version settings to the source


### PR DESCRIPTION
Version numbers need to be updated to ROCm 6.2

Version = 1.3.0 for ROCm 6.2

Update changelog placeholder