### PR TITLE
Fix linting workflow and codeowner syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 * @cgmillette @bragadeesh @mkarunan @dlangbe @congma13 @afanfa
 # Documentation files
-docs/* @ROCm/rocm-documentation
+docs/ @ROCm/rocm-documentation
 *.md @ROCm/rocm-documentation
 *.rst @ROCm/rocm-documentation
 .readthedocs.yaml @ROCm/rocm-documentation
 # Header directory
-library/include/* @ROCm/rocm-documentation @cgmillette @bragadeesh @mkarunan @dlangbe @congma13 @afanfa
+library/include/ @ROCm/rocm-documentation @cgmillette @bragadeesh @mkarunan @dlangbe @congma13 @afanfa

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,11 +2,17 @@ name: Linting
 
 on:
   push:
-    branches: [develop]
+    branches: 
+    - develop
+    - master
+    - 'docs/*'
   pull_request:
-    branches: [develop]
+    branches: 
+    - develop
+    - master
+    - 'docs/*'
 
 jobs:
   call-workflow-passing-data:
     name: Documentation
-    uses: RadeonOpenCompute/rocm-docs-core/.github/workflows/linting.yml@develop
+    uses: ROCm/rocm-docs-core/.github/workflows/linting.yml@develop


### PR DESCRIPTION
Update organization to ROCm for linting workflow

Use / in codeowner for pattern to include nested files and folders

RE: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
RE: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners