### PR TITLE
Remove the apostrophe in package description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 
 rocm_create_package(
     NAME hiptensor
-    DESCRIPTION "AMD's high-performance HIP library for tensor primitives"
+    DESCRIPTION "AMD high-performance HIP library for tensor primitives"
     MAINTAINER "hiptensor Maintainer <hiptensor-maintainer@amd.com>"
     LDCONFIG
 )


### PR DESCRIPTION
While creating wheel package, the rpm tags are read from the rpm package. The apostrophe in the package description is causing syntax error while parsing the descritpion tag.