### PR TITLE
Add -mcmodel=large for ASAN pipeline

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -60,6 +60,15 @@ include_directories(BEFORE
     ${PROJECT_SOURCE_DIR}/library/src/include
 )
 
+if (NOT DEFINED ADDRESS_SANITIZER AND DEFINED ENV{ADDRESS_SANITIZER})
+    set(ADDRESS_SANITIZER $ENV{ADDRESS_SANITIZER})
+endif()
+
+if (ADDRESS_SANITIZER OR CMAKE_CXX_FLAGS MATCHES "-fsanitize=address")
+    add_compile_options(-mcmodel=large)
+    add_link_options(-mcmodel=large)
+endif()
+
 # Generates hiptensor_contraction and hiptensor_contraction_instances
 add_subdirectory(contraction)
 # Generates hiptensor_permutation and hiptensor_permutation_instances


### PR DESCRIPTION
Goal
Provide ASAN instrumented builds of all AMD built libraries
Improve release quality by running instrumented tests

Problem
hiptensor library is larger than 2GB if ASAN is enabled. 

Solution
Add -mcmodel=large for ASAN pipeline

1. Check if CMake variable ADDRESS_SANITIZER is true
2. Check if env variable ADDRESS_SANITIZER is true
3. Check if CXXFLAGS contains "-fsanitize=address"

Tested with ASAN docker