### PR TITLE
Update gfxTargets for ASAN pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,23 @@ include(ROCMPackageConfigHelpers)
 include(ROCMInstallSymlinks)
 include(CheckCXXCompilerFlag)
 
+# check if asan is enabled
+if (NOT DEFINED ADDRESS_SANITIZER AND DEFINED ENV{ADDRESS_SANITIZER})
+    set(ADDRESS_SANITIZER $ENV{ADDRESS_SANITIZER})
+endif()
+if (ADDRESS_SANITIZER OR CMAKE_CXX_FLAGS MATCHES "-fsanitize=address")
+    set(ADDRESS_SANITIZER_ENABLED ON)
+else()
+    set(ADDRESS_SANITIZER_ENABLED OFF)
+endif()
+
+if (ADDRESS_SANITIZER_ENABLED)
 rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-  TARGETS "gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx940;gfx941;gfx942" )
+    TARGETS "gfx90a:xnack+;gfx940:xnack+;gfx941:xnack+;gfx942:xnack+" )
+else()
+rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
+    TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942" )
+endif()
 
 # Variable AMDGPU_TARGET must be a cached variable and must be specified before calling find_package(hip)
 # This is because hip-config.cmake sets --offload-arch via AMDGPU_TARGET cached variable __after__ setting

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -60,11 +60,7 @@ include_directories(BEFORE
     ${PROJECT_SOURCE_DIR}/library/src/include
 )
 
-if (NOT DEFINED ADDRESS_SANITIZER AND DEFINED ENV{ADDRESS_SANITIZER})
-    set(ADDRESS_SANITIZER $ENV{ADDRESS_SANITIZER})
-endif()
-
-if (ADDRESS_SANITIZER OR CMAKE_CXX_FLAGS MATCHES "-fsanitize=address")
+if (ADDRESS_SANITIZER_ENABLED)
     add_compile_options(-mcmodel=large)
     add_link_options(-mcmodel=large)
 endif()


### PR DESCRIPTION
ASAN needs xnack feature. Enable xnack of all targets.

command used for asan VS. command used for non-asan

![image](https://github.com/ROCm/hipTensor/assets/142121551/398847fd-a5c2-47cc-87a3-fd54ccb13e90)
