### PR TITLE
New fill kernel and validation tolerances

### DIFF
--- a/library/src/data_types.cpp
+++ b/library/src/data_types.cpp
@@ -254,6 +254,102 @@ namespace hiptensor
             return;
         }
     }
+
+    std::string computeTypeToString(hiptensorComputeType_t computeType)
+    {
+        if(computeType == HIPTENSOR_COMPUTE_16BF)
+        {
+            return "HIPTENSOR_COMPUTE_16BF";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_16F)
+        {
+            return "HIPTENSOR_COMPUTE_16F";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_32F)
+        {
+            return "HIPTENSOR_COMPUTE_32F";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_64F)
+        {
+            return "HIPTENSOR_COMPUTE_64F";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_8I)
+        {
+            return "HIPTENSOR_COMPUTE_8I";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_8U)
+        {
+            return "HIPTENSOR_COMPUTE_8U";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_32I)
+        {
+            return "HIPTENSOR_COMPUTE_32I";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_32U)
+        {
+            return "HIPTENSOR_COMPUTE_32U";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_C32F)
+        {
+            return "HIPTENSOR_COMPUTE_C32F";
+        }
+        else if(computeType == HIPTENSOR_COMPUTE_C64F)
+        {
+            return "HIPTENSOR_COMPUTE_C64F";
+        }
+        else
+        {
+            return "HIPTENSOR_COMPUTE_NONE";
+        }
+    }
+
+    std::string hipTypeToString(hipDataType hipType)
+    {
+        if(hipType == HIP_R_16BF)
+        {
+            return "HIP_R_16BF";
+        }
+        else if(hipType == HIP_R_16F)
+        {
+            return "HIP_R_16F";
+        }
+        else if(hipType == HIP_R_32F)
+        {
+            return "HIP_R_32F";
+        }
+        else if(hipType == HIP_R_64F)
+        {
+            return "HIP_R_64F";
+        }
+        else if(hipType == HIP_R_8I)
+        {
+            return "HIP_R_8I";
+        }
+        else if(hipType == HIP_R_8U)
+        {
+            return "HIP_R_8U";
+        }
+        else if(hipType == HIP_R_32I)
+        {
+            return "HIP_R_32I";
+        }
+        else if(hipType == HIP_R_32U)
+        {
+            return "HIP_R_32U";
+        }
+        else if(hipType == HIP_C_32F)
+        {
+            return "HIP_C_32F";
+        }
+        else if(hipType == HIP_C_64F)
+        {
+            return "HIP_C_64F";
+        }
+        else
+        {
+            return "HIP_TYPE_NONE";
+        }
+    }
 } // namespace hiptensor
 
 bool operator==(hipDataType hipType, hiptensorComputeType_t computeType)

--- a/library/src/include/data_types.hpp
+++ b/library/src/include/data_types.hpp
@@ -107,6 +107,9 @@ namespace hiptensor
     T readVal(void const* value, hiptensorComputeType_t id);
 
     void writeVal(void const* addr, hiptensorComputeType_t id, ScalarData value);
+
+    std::string computeTypeToString(hiptensorComputeType_t computeType);
+    std::string hipTypeToString(hipDataType hipType);
 } // namespace hiptensor
 
 bool operator==(hipDataType hipType, hiptensorComputeType_t computeType);

--- a/test/01_contraction/contraction_test.cpp
+++ b/test/01_contraction/contraction_test.cpp
@@ -266,7 +266,6 @@ namespace hiptensor
                 fillLaunchKernel<_Float16>((_Float16*)resource->deviceB().get(), elementsB, seed);
                 if(CDataType == HIP_R_16F)
                 {
-                    printf("Filling C\n\n");
                     fillLaunchKernel<_Float16>((_Float16*)resource->deviceC().get(), elementsCD, seed + 1);
                 }
                 fillValLaunchKernel<_Float16>((_Float16*)resource->deviceD().get(),
@@ -666,7 +665,8 @@ namespace hiptensor
                                             size_t{1},
                                             std::multiplies<size_t>());
 
-            auto eps = getEpsilon(computeType);
+            auto eps = getEpsilon(computeType == HIPTENSOR_COMPUTE_64F ? HIPTENSOR_COMPUTE_64F
+                : HIPTENSOR_COMPUTE_32F);
             double tolerance = 2 * nelems_k * eps;
 
             // use the same default tolerance value as CK

--- a/test/01_contraction/contraction_test.cpp
+++ b/test/01_contraction/contraction_test.cpp
@@ -257,14 +257,17 @@ namespace hiptensor
             auto resource = getResource();
             resource->resizeStorage(lengths, elementBytes);
 
+            uint32_t seed = static_cast<uint32_t>(std::time(nullptr));
+
             if(ADataType == HIP_R_16F && BDataType == HIP_R_16F && DDataType == HIP_R_16F)
             {
                 // Initialize matrix data on device
-                fillLaunchKernel<_Float16>((_Float16*)resource->deviceA().get(), elementsA);
-                fillLaunchKernel<_Float16>((_Float16*)resource->deviceB().get(), elementsB);
+                fillLaunchKernel<_Float16>((_Float16*)resource->deviceA().get(), elementsA, seed - 1);
+                fillLaunchKernel<_Float16>((_Float16*)resource->deviceB().get(), elementsB, seed);
                 if(CDataType == HIP_R_16F)
                 {
-                    fillLaunchKernel<_Float16>((_Float16*)resource->deviceC().get(), elementsCD);
+                    printf("Filling C\n\n");
+                    fillLaunchKernel<_Float16>((_Float16*)resource->deviceC().get(), elementsCD, seed + 1);
                 }
                 fillValLaunchKernel<_Float16>((_Float16*)resource->deviceD().get(),
                                               elementsCD,
@@ -273,12 +276,12 @@ namespace hiptensor
             else if(ADataType == HIP_R_16BF && BDataType == HIP_R_16BF && DDataType == HIP_R_16BF)
             {
                 // Initialize matrix data on device
-                fillLaunchKernel<hip_bfloat16>((hip_bfloat16*)resource->deviceA().get(), elementsA);
-                fillLaunchKernel<hip_bfloat16>((hip_bfloat16*)resource->deviceB().get(), elementsB);
+                fillLaunchKernel<hip_bfloat16>((hip_bfloat16*)resource->deviceA().get(), elementsA, seed - 1);
+                fillLaunchKernel<hip_bfloat16>((hip_bfloat16*)resource->deviceB().get(), elementsB, seed);
                 if(CDataType == HIP_R_16BF)
                 {
                     fillLaunchKernel<hip_bfloat16>((hip_bfloat16*)resource->deviceC().get(),
-                                                   elementsCD);
+                                                   elementsCD, seed + 1);
                 }
                 fillValLaunchKernel<hip_bfloat16>(
                     (hip_bfloat16*)resource->deviceD().get(),
@@ -288,11 +291,11 @@ namespace hiptensor
             else if(ADataType == HIP_R_32F && BDataType == HIP_R_32F && DDataType == HIP_R_32F)
             {
                 // Initialize matrix data on device
-                fillLaunchKernel<float>((float*)resource->deviceA().get(), elementsA);
-                fillLaunchKernel<float>((float*)resource->deviceB().get(), elementsB);
+                fillLaunchKernel<float>((float*)resource->deviceA().get(), elementsA, seed - 1);
+                fillLaunchKernel<float>((float*)resource->deviceB().get(), elementsB, seed);
                 if(CDataType == HIP_R_32F)
                 {
-                    fillLaunchKernel<float>((float*)resource->deviceC().get(), elementsCD);
+                    fillLaunchKernel<float>((float*)resource->deviceC().get(), elementsCD, seed + 1);
                 }
                 fillValLaunchKernel<float>((float*)resource->deviceD().get(),
                                            elementsCD,
@@ -301,11 +304,11 @@ namespace hiptensor
             else if(ADataType == HIP_R_64F && BDataType == HIP_R_64F && DDataType == HIP_R_64F)
             {
                 // Initialize matrix data on device
-                fillLaunchKernel<double>((double*)resource->deviceA().get(), elementsA);
-                fillLaunchKernel<double>((double*)resource->deviceB().get(), elementsB);
+                fillLaunchKernel<double>((double*)resource->deviceA().get(), elementsA, seed - 1);
+                fillLaunchKernel<double>((double*)resource->deviceB().get(), elementsB, seed);
                 if(CDataType == HIP_R_64F)
                 {
-                    fillLaunchKernel<double>((double*)resource->deviceC().get(), elementsCD);
+                    fillLaunchKernel<double>((double*)resource->deviceC().get(), elementsCD, seed + 1);
                 }
                 fillValLaunchKernel<double>((double*)resource->deviceD().get(),
                                             elementsCD,
@@ -315,13 +318,13 @@ namespace hiptensor
             {
                 // Initialize matrix data on device
                 fillLaunchKernel<hipFloatComplex>((hipFloatComplex*)resource->deviceA().get(),
-                                                  elementsA);
+                                                  elementsA, seed - 1);
                 fillLaunchKernel<hipFloatComplex>((hipFloatComplex*)resource->deviceB().get(),
-                                                  elementsB);
+                                                  elementsB, seed);
                 if(CDataType == HIP_C_32F)
                 {
                     fillLaunchKernel<hipFloatComplex>((hipFloatComplex*)resource->deviceC().get(),
-                                                      elementsCD);
+                                                      elementsCD, seed + 1);
                 }
                 fillValLaunchKernel<hipFloatComplex>(
                     (hipFloatComplex*)resource->deviceD().get(),
@@ -332,13 +335,13 @@ namespace hiptensor
             {
                 // Initialize matrix data on device
                 fillLaunchKernel<hipDoubleComplex>((hipDoubleComplex*)resource->deviceA().get(),
-                                                   elementsA);
+                                                   elementsA, seed - 1);
                 fillLaunchKernel<hipDoubleComplex>((hipDoubleComplex*)resource->deviceB().get(),
-                                                   elementsB);
+                                                   elementsB, seed);
                 if(CDataType == HIP_C_64F)
                 {
                     fillLaunchKernel<hipDoubleComplex>((hipDoubleComplex*)resource->deviceC().get(),
-                                                       elementsCD);
+                                                       elementsCD, seed + 1);
                 }
                 fillValLaunchKernel<hipDoubleComplex>(
                     (hipDoubleComplex*)resource->deviceD().get(),

--- a/test/01_contraction/contraction_test.cpp
+++ b/test/01_contraction/contraction_test.cpp
@@ -257,7 +257,7 @@ namespace hiptensor
             auto resource = getResource();
             resource->resizeStorage(lengths, elementBytes);
 
-            uint32_t seed = static_cast<uint32_t>(std::time(nullptr));
+            uint32_t seed = static_cast<uint32_t>(256);
 
             if(ADataType == HIP_R_16F && BDataType == HIP_R_16F && DDataType == HIP_R_16F)
             {

--- a/test/02_permutation/permutation_resource.cpp
+++ b/test/02_permutation/permutation_resource.cpp
@@ -96,13 +96,15 @@ namespace hiptensor
 
     void PermutationResource::fillRandToA()
     {
+        uint32_t seed = static_cast<uint32_t>(std::time(nullptr));
+        
         if(mCurrentDataType == HIP_R_32F)
         {
-            fillLaunchKernel<float>((float*)deviceA().get(), mCurrentMatrixElement);
+            fillLaunchKernel<float>((float*)deviceA().get(), mCurrentMatrixElement, seed);
         }
         else
         {
-            fillLaunchKernel<_Float16>((_Float16*)deviceA().get(), mCurrentMatrixElement);
+            fillLaunchKernel<_Float16>((_Float16*)deviceA().get(), mCurrentMatrixElement, seed);
         }
         Base::copyData(hostA(), deviceA(), getCurrentMatrixMemorySize());
     }

--- a/test/02_permutation/permutation_resource.cpp
+++ b/test/02_permutation/permutation_resource.cpp
@@ -96,7 +96,7 @@ namespace hiptensor
 
     void PermutationResource::fillRandToA()
     {
-        uint32_t seed = static_cast<uint32_t>(std::time(nullptr));
+        uint32_t seed = static_cast<uint32_t>(256);
         
         if(mCurrentDataType == HIP_R_32F)
         {

--- a/test/03_reduction/reduction_resource.cpp
+++ b/test/03_reduction/reduction_resource.cpp
@@ -127,7 +127,7 @@ namespace hiptensor
 
     void ReductionResource::fillRand(HostPtrT& hostBuf, DevicePtrT& deviceBuf, size_t elementCount)
     {
-        uint32_t seed = static_cast<uint32_t>(std::time(nullptr));
+        uint32_t seed = static_cast<uint32_t>(256);
 
         if(mCurrentDataType == HIP_R_16F)
         {

--- a/test/03_reduction/reduction_resource.cpp
+++ b/test/03_reduction/reduction_resource.cpp
@@ -127,21 +127,23 @@ namespace hiptensor
 
     void ReductionResource::fillRand(HostPtrT& hostBuf, DevicePtrT& deviceBuf, size_t elementCount)
     {
+        uint32_t seed = static_cast<uint32_t>(std::time(nullptr));
+
         if(mCurrentDataType == HIP_R_16F)
         {
-            fillLaunchKernel<float16_t>((float16_t*)deviceBuf.get(), elementCount);
+            fillLaunchKernel<float16_t>((float16_t*)deviceBuf.get(), elementCount, seed);
         }
         else if(mCurrentDataType == HIP_R_16BF)
         {
-            fillLaunchKernel<bfloat16_t>((bfloat16_t*)deviceBuf.get(), elementCount);
+            fillLaunchKernel<bfloat16_t>((bfloat16_t*)deviceBuf.get(), elementCount, seed);
         }
         else if(mCurrentDataType == HIP_R_32F)
         {
-            fillLaunchKernel<float32_t>((float32_t*)deviceBuf.get(), elementCount);
+            fillLaunchKernel<float32_t>((float32_t*)deviceBuf.get(), elementCount, seed);
         }
         else if(mCurrentDataType == HIP_R_64F)
         {
-            fillLaunchKernel<float64_t>((float64_t*)deviceBuf.get(), elementCount);
+            fillLaunchKernel<float64_t>((float64_t*)deviceBuf.get(), elementCount, seed);
         }
         Base::copyData(hostBuf, deviceBuf, elementCount);
     }

--- a/test/device/common.hpp
+++ b/test/device/common.hpp
@@ -82,25 +82,26 @@ __device__ inline float gen_random_float(unsigned input)
 
 // fill kernel for 'elementSize' elements
 template <typename DataType>
-__global__ void fillKernel(DataType* data, uint32_t elementSize)
+__global__ void fillKernel(DataType* data, uint32_t elementSize, uint32_t seed)
 {
     uint32_t index = (blockIdx.x * blockDim.x + threadIdx.x);
+    uint32_t seededIndex = static_cast<uint32_t>(uint64_t(index + seed) % UINT_MAX);
 
     if(index < elementSize)
     {
         if constexpr(std::is_same_v<DataType, hipFloatComplex>)
         {
-            auto value  = gen_random_float(index);
+            auto value  = gen_random_float(seededIndex);
             data[index] = make_hipFloatComplex(value, value);
         }
         else if constexpr(std::is_same_v<DataType, hipDoubleComplex>)
         {
-            auto value  = static_cast<double>(gen_random_float(index));
+            auto value  = static_cast<double>(gen_random_float(seededIndex));
             data[index] = make_hipDoubleComplex(value, value);
         }
         else
         {
-            auto value  = gen_random_float(index);
+            auto value  = gen_random_float(seededIndex);
             data[index] = static_cast<DataType>(value);
         }
     }

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -350,8 +350,6 @@ std::pair<bool, double> compareEqualLaunchKernel(DDataType*             deviceD,
     auto toDouble
         = [](DDataType const& val) { return static_cast<double>(static_cast<float>(val)); };
 
-    auto eps = getEpsilon(computeType);
-
     if(tolerance == 0.0)
     {
         // use the same default tolerance value as CK

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -164,7 +164,7 @@ auto getProduct(const Container&               container,
 
 // fill kernel for 'elementSize' elements
 template <typename DataType>
-__host__ static inline void fillLaunchKernel(DataType* data, uint32_t elementSize)
+__host__ static inline void fillLaunchKernel(DataType* data, uint32_t elementSize, uint32_t seed)
 {
     auto blockDim = dim3(1024, 1, 1);
     auto gridDim  = dim3(ceilDiv(elementSize, blockDim.x), 1, 1);
@@ -174,7 +174,8 @@ __host__ static inline void fillLaunchKernel(DataType* data, uint32_t elementSiz
                        0,
                        0,
                        data,
-                       elementSize);
+                       elementSize,
+                       seed);
 }
 
 // fill kernel wrapper for 'elementSize' elements with a specific value


### PR DESCRIPTION
Implements the new fill kernel from [PR 236](https://github.com/ROCm/hipTensor/pull/236) with supporting changes to the validation thresholds used throughout the testing infrastructure. The new validation thresholds should guarantee that validating CK kernels will also validate when used within hipTensor.