### PR TITLE
Workaround for rocm-cmake issue in asan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,11 +96,12 @@ else()
 endif()
 
 if (ADDRESS_SANITIZER_ENABLED)
-rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-    TARGETS "gfx90a:xnack+;gfx940:xnack+;gfx941:xnack+;gfx942:xnack+" )
+    set(CMAKE_NO_BUILTIN_CHRPATH ON)
+    rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
+        TARGETS "gfx90a:xnack+;gfx940:xnack+;gfx941:xnack+;gfx942:xnack+" )
 else()
-rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-    TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942" )
+    rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
+        TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942" )
 endif()
 
 # Variable AMDGPU_TARGET must be a cached variable and must be specified before calling find_package(hip)


### PR DESCRIPTION
hipTensor could not be installed after the updating of rocm-cmake.

Found a workaround for this.

See https://gitlab.kitware.com/cmake/cmake/-/issues/24877