### PR TITLE
Add missing handle and event destroys

### DIFF
--- a/library/src/contraction/hiptensor_contraction.cpp
+++ b/library/src/contraction/hiptensor_contraction.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -573,6 +573,9 @@ hiptensorStatus_t hiptensorInitContractionPlan(const hiptensorHandle_t*         
 
     auto elapsedTimeMs = 0.0f;
     CHECK_HIP_ERROR(hipEventElapsedTime(&elapsedTimeMs, startEvent, stopEvent));
+
+    CHECK_HIP_ERROR(hipEventDestroy(startEvent));
+    CHECK_HIP_ERROR(hipEventDestroy(stopEvent));
 
     if(result != HIPTENSOR_STATUS_SUCCESS)
     {

--- a/test/03_reduction/reduction_test.cpp
+++ b/test/03_reduction/reduction_test.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -447,6 +447,12 @@ namespace hiptensor
         }
     }
 
-    void ReductionTest::TearDown() {}
+    void ReductionTest::TearDown()
+    {
+        if(mRunFlag)
+        {
+            CHECK_HIPTENSOR_ERROR(hiptensorDestroy(handle));
+        }
+    }
 
 } // namespace hiptensor


### PR DESCRIPTION
Fixes memory leaks in hipTensor tests.
Related to https://github.com/ROCm/composable_kernel/pull/1555
