### PR TITLE
Add compiling flag --offload-compress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ # Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal
@@ -67,6 +67,16 @@ if( CMAKE_PROJECT_NAME STREQUAL "hiptensor" )
   option( HIPTENSOR_BUILD_SAMPLES "Build hiptensor samples" ON )
   option( HIPTENSOR_BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)
   option( HIPTENSOR_DATA_LAYOUT_COL_MAJOR "Set hiptensor data layout to column major" ON )
+  option(BUILD_OFFLOAD_COMPRESS "Build hiptensor with offload compression" ON)
+endif()
+
+# Check if offload compression is supported
+include(CheckCXXCompilerFlag)
+if (BUILD_OFFLOAD_COMPRESS)
+  check_cxx_compiler_flag("--offload-compress" CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+  if (NOT CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+    message( STATUS "WARNING: BUILD_OFFLOAD_COMPRESS=ON but flag not supported by compiler. Ignoring option." )
+  endif()
 endif()
 
 # Setup output paths

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -46,6 +46,11 @@ function(add_hiptensor_component COMPONENT_NAME COMPONENT_SOURCES)
     target_link_options(${COMPONENT_NAME} PRIVATE ${CLANG_DRIVER_MODE})
     set_target_properties(${COMPONENT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(${COMPONENT_NAME} PRIVATE hip::device)
+    # Use offload compress flag if it is supported
+    if(BUILD_OFFLOAD_COMPRESS AND CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+        target_compile_options(${COMPONENT_NAME} PRIVATE "--offload-compress" )
+    endif()
+
     if(HIPTENSOR_BUILD_COMPRESSED_DBG)
         target_compile_options(${COMPONENT_NAME} PRIVATE
             "$<$<CONFIG:Debug>:-gz>"
@@ -101,6 +106,11 @@ add_library(hiptensor::hiptensor ALIAS hiptensor)
 # Add driver mode to both cxx and link flags
 target_compile_options(hiptensor PRIVATE ${CMAKE_CXX_FLAGS} ${CLANG_DRIVER_MODE})
 target_link_options(hiptensor PRIVATE ${CLANG_DRIVER_MODE})
+
+# Use offload compress flag if it is supported
+if(BUILD_OFFLOAD_COMPRESS AND CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+    target_compile_options(hiptensor PRIVATE "--offload-compress" )
+endif()
 
 # Compressed debug symbols flags
 if(HIPTENSOR_BUILD_COMPRESSED_DBG)


### PR DESCRIPTION
The the size of binary files is much smaller with this flag.

The size of libhiptensor.so shrinks from 215M to 145M. (Release and only for gfx90a)


See https://github.com/ROCm/rocBLAS-internal/pull/2707