### PR TITLE
Remove targets 940 and 941

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ # Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal
@@ -98,10 +98,10 @@ endif()
 if (ADDRESS_SANITIZER_ENABLED)
     set(CMAKE_NO_BUILTIN_CHRPATH ON)
     rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-        TARGETS "gfx90a:xnack+;gfx940:xnack+;gfx941:xnack+;gfx942:xnack+" )
+        TARGETS "gfx90a:xnack+;gfx942:xnack+" )
 else()
     rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-        TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942" )
+        TARGETS "gfx908;gfx90a;gfx942" )
 endif()
 
 # Variable AMDGPU_TARGET must be a cached variable and must be specified before calling find_package(hip)


### PR DESCRIPTION
Stop building 940 and 941 targets in Rocm 6.3