### PR TITLE
Remove `__device__ ck::math::cos`

### DIFF
--- a/library/src/include/hiptensor_unary_element_wise_operation.hpp
+++ b/library/src/include/hiptensor_unary_element_wise_operation.hpp
@@ -35,6 +35,32 @@
 
 #include <hiptensor/hiptensor_types.hpp>
 
+namespace hiptensor {
+	namespace math
+	{
+		template <typename T>
+			inline __host__ __device__ T cos(T x)
+			{
+				return ck::type_convert<T>(::cosf(ck::type_convert<float>(x)));
+			};
+		template <>
+			inline __host__ __device__ float cos<float>(float x)
+			{
+				return ::cosf(x);
+			};
+		template <>
+			inline __host__ __device__ double cos<double>(double x)
+			{
+				return ::cos(x);
+			};
+		template <>
+			inline __host__ __device__ ck::half_t cos<ck::half_t>(ck::half_t x)
+			{
+				return hcos(static_cast<__half>(x));
+			};
+	}
+}
+
 namespace ck
 {
     namespace tensor_operation
@@ -93,7 +119,7 @@ namespace ck
             }
             __host__ __device__ static void hiptensor_cos(float& y, float const& x)
             {
-                y = ck::math::cos(x);
+                y = hiptensor::math::cos(x);
             }
             __host__ __device__ static void hiptensor_tan(float& y, float const& x)
             {

--- a/library/src/include/hiptensor_unary_element_wise_operation.hpp
+++ b/library/src/include/hiptensor_unary_element_wise_operation.hpp
@@ -37,29 +37,6 @@
 
 namespace ck
 {
-    namespace math
-    {
-        template <typename T>
-        inline __device__ T cos(T x)
-        {
-            return ck::type_convert<T>(::cosf(ck::type_convert<float>(x)));
-        };
-        template <>
-        inline __device__ float cos<float>(float x)
-        {
-            return ::cosf(x);
-        };
-        template <>
-        inline __device__ double cos<double>(double x)
-        {
-            return ::cos(x);
-        };
-        template <>
-        inline __device__ half_t cos<half_t>(half_t x)
-        {
-            return hcos(static_cast<__half>(x));
-        };
-    }
     namespace tensor_operation
     {
         namespace element_wise

--- a/library/src/include/hiptensor_unary_element_wise_operation.hpp
+++ b/library/src/include/hiptensor_unary_element_wise_operation.hpp
@@ -36,6 +36,10 @@
 #include <hiptensor/hiptensor_types.hpp>
 
 namespace hiptensor {
+	// This hiptensor::math::cos is a workaround for a CK missing function issue.
+	// CK has fixed the issue in develop branch, but it has not been made into all
+	// CI pipelines.
+	// TODO Remove hiptensor::math::cos when `__device__ ck::math::cos` is available in all pipelines.
 	namespace math
 	{
 		template <typename T>


### PR DESCRIPTION
There was an issue in CK that `__device__ ck::math::cos` was missing.

Added the definition of `cos` function in hiptensor as a workaround of this issue. Remove the `cos` function in this commit since CK has added it.