### PR TITLE
Remove absolute path in RUNPATH

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -24,6 +24,9 @@
  #
  ###############################################################################
 
+#Prevent CMake to add building path to RUNPATH
+set(CMAKE_SKIP_RPATH  TRUE)
+
 # Check whether building within hiptensor context
 if( CMAKE_PROJECT_NAME STREQUAL "hiptensor" )
     # Target that will trigger build of all samples
@@ -40,7 +43,8 @@ if( CMAKE_PROJECT_NAME STREQUAL "hiptensor" )
 
         # Sample must propagate the build interface includes to make sure
         # hiptensor includes are captured at runtime.
-        target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+        target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
+                              "-fno-rtlib-add-rpath")
         target_include_directories(${BINARY_NAME} PRIVATE
                                 ${CMAKE_CURRENT_SOURCE_DIR}
                                 ${PROJECT_SOURCE_DIR}/samples

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,9 @@ add_custom_target(hiptensor_tests)
 set(HIPTENSOR_COMMON_TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/hip_resource.cpp
                                   ${CMAKE_CURRENT_SOURCE_DIR}/hiptensor_gtest_main.cpp)
 
+#Prevent CMake to add building path to RUNPATH
+set(CMAKE_SKIP_RPATH  TRUE)
+
 # Create test executables and deploy
 function(add_hiptensor_test BINARY_NAME YAML_CONFIG_FILE TEST_SOURCES)
 
@@ -100,7 +103,8 @@ function(add_hiptensor_test BINARY_NAME YAML_CONFIG_FILE TEST_SOURCES)
 
     # Test must propagate the build interface includes to make sure
     # hiptensor includes are captured at runtime.
-    target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor hiptensor_llvm gtest "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+    target_link_libraries(${BINARY_NAME} PRIVATE hiptensor::hiptensor hiptensor_llvm gtest "-L${HIP_CLANG_ROOT}/lib"
+                          "-Wl,-rpath=$ORIGIN/../${CMAKE_INSTALL_LIBDIR}" "-fno-rtlib-add-rpath")
 
     target_include_directories(${BINARY_NAME} PRIVATE
                                ${CMAKE_CURRENT_SOURCE_DIR}

--- a/test/llvm/CMakeLists.txt
+++ b/test/llvm/CMakeLists.txt
@@ -61,12 +61,6 @@ if(NOT LLVMSupport_LIBRARY)
 endif()
 
 # LLVM Libs we need to link against
-#set(HIPTENSOR_LLVM_LIBS "-L${LLVM_LIBRARY_DIR}"
-#                        "-Wl,-rpath=${LLVM_LIBRARY_DIR}"
-#                        LLVMObjectYAML
-#                        LLVMSupport
-#                        hip::device
-#                        )
 set(HIPTENSOR_LLVM_LIBS "-L${LLVM_LIBRARY_DIR}"
                         "-fno-rtlib-add-rpath"
                         LLVMObjectYAML

--- a/test/llvm/CMakeLists.txt
+++ b/test/llvm/CMakeLists.txt
@@ -61,8 +61,14 @@ if(NOT LLVMSupport_LIBRARY)
 endif()
 
 # LLVM Libs we need to link against
+#set(HIPTENSOR_LLVM_LIBS "-L${LLVM_LIBRARY_DIR}"
+#                        "-Wl,-rpath=${LLVM_LIBRARY_DIR}"
+#                        LLVMObjectYAML
+#                        LLVMSupport
+#                        hip::device
+#                        )
 set(HIPTENSOR_LLVM_LIBS "-L${LLVM_LIBRARY_DIR}"
-                        "-Wl,-rpath=${LLVM_LIBRARY_DIR}"
+                        "-fno-rtlib-add-rpath"
                         LLVMObjectYAML
                         LLVMSupport
                         hip::device


### PR DESCRIPTION
This branch is a fix for JIRA hipTensor[LWPHIPTENS-401] (https://ontrack-internal.amd.com/browse/LWPHIPTENS-401)

In "hipTensor/samples/CMakeLists.txt", "hipTensor/test/CMakeLists.txt" and "hipTensor/test/llvm/CMakeLists.txt", following two options are added:
1. set(CMAKE_SKIP_RPATH  TRUE) 
   to prevent CMake to add buiding path etc. to RUNPATH.
2. "-fno-rtlib-add-rpath" to target_link_libraries.
   This prevents hipcc to add -rpath with architecture-specific resource directory to the linker flags.

Test was performed in a docker container and it shows that only [$ORIGIN/../lib] is in the RUNPATH of all executables now.