### PR TITLE
Cherry-pick to release-staging/rocm-rel-6.5: First phase of hipTensor docs refresh (#351)

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -17,3 +17,4 @@ mandatorily
 markdownlint
 ol
 rocm
+trinary

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dependencies:
 * Minimum ROCm-cmake version support is 0.8.0.
 * Minimum Composable Kernel version support is composable_kernel 1.1.0 for ROCm 6.0.2 (or ROCm package composablekernel-dev).
 * Minimum HIP runtime version support is 4.3.0 (or ROCm package ROCm hip-runtime-amd).
-* Minimum LLVM dev package version support is 10.0 (available as ROCm package rocm-llvm-dev).
+* Minimum LLVM dev package version support is 7.0 (available as ROCm package rocm-llvm-dev).
 
 Optional:
 

--- a/docs/conceptual/programmers-guide.rst
+++ b/docs/conceptual/programmers-guide.rst
@@ -5,7 +5,7 @@
 .. _programmers-guide:
 
 ===================
-Programmer's guide
+Programming guide
 ===================
 
 This document provides insight into the library source code organization, design implementation details, helpful information for new development, and testing and benchmarking details.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ left_nav_title = f"hipTensor {version_number} Documentation"
 # for PDF output on Read the Docs
 project = "hipTensor Documentation"
 author = "Advanced Micro Devices, Inc."
-copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+copyright = "Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved."
 version = version_number
 release = version_number
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. meta::
-   :description: A high-performance HIP library for tensor primitives
+   :description: Introduction to the high-performance hipTensor library for tensor primitives
    :keywords: hipTensor, ROCm, library, API, tool
 
 .. _index:
@@ -8,37 +8,42 @@
 hipTensor documentation
 ===========================
 
-hipTensor is a work-in-progress (WIP) high-performance Heterogeneous-Compute Interface for Portability (HIP) library for tensor primitives. It’s AMD’s C++ library for accelerating tensor primitives, which can leverage specialized GPU matrix cores on AMD’s latest discrete GPUs. hipTensor is currently powered by the composable kernel (CK) library backend. The API is designed to be portable with the NVIDIA CUDA cuTensor library, allowing those users to easily migrate to the AMD platform.
+hipTensor is a high-performance C++ :doc:`HIP <hip:index>` (Heterogeneous-Compute Interface for Portability)
+library for accelerating tensor primitives.
+It leverages specialized GPU matrix cores on the latest AMD discrete GPUs.
+The hipTensor API is designed to be portable with the NVIDIA CUDA cuTensor library,
+letting CUDA users easily migrate to the AMD platform. The hipTensor library is a work in progress (WIP).
+For more information, see :doc:`What is hipTensor? <./what-is-hiptensor>`
 
-The hipTensor API offers functionality for defining tensor data objects and currently supports contraction, permutation and reduction operations on the tensor objects. Users may also control several available logging options. The hipTensor library is bundled with GPU kernel instances, which are automatically selected and invoked to solve problems as defined by the API input parameters. As hipTensor is a WIP, future tensor operation support might include additional element-wise operations and caching of selection instances.
 
-Supporting host code is required for GPU device and memory management. The hipTensor code samples and tests provided are built and launched via the HIP ecosystem within ROCm.
-
-hipTensor library code is open source and available via the `GitHub repository <https://github.com/ROCm/hipTensor>`_.
-
-The documentation is structured as follows:
+The hipTensor public repository is located at `<https://github.com/ROCm/hipTensor>`_.
 
 .. grid:: 2
   :gutter: 3
 
   .. grid-item-card:: Install
 
-    * :ref:`installation`
+    * :doc:`Installation guide <./install/installation>`
+
+.. grid:: 2
+  :gutter: 3
 
   .. grid-item-card:: Conceptual
 
-    * :ref:`programmers-guide`
+    * :doc:`Programming guide <./conceptual/programmers-guide>`
+
+  .. grid-item-card:: How to
+
+    * :doc:`Contribute to hipTensor <./contribution/contributors-guide>`
+
+  .. grid-item-card:: Examples
+
+    * `Samples <https://github.com/ROCm/hipTensor/tree/develop/samples>`_
 
   .. grid-item-card:: API reference
 
-    * :ref:`api-reference`
+    * :doc:`API reference guide <./api-reference/api-reference>`
 
-  .. grid-item-card:: Contribution
+To contribute to the documentation, see `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 
-    * :ref:`contributors-guide`
-
-To contribute to the documentation refer to
-`Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
-
-Licensing information can be found on the
-`Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.
+You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.

--- a/docs/install/installation.rst
+++ b/docs/install/installation.rst
@@ -1,273 +1,262 @@
 .. meta::
-   :description: A high-performance HIP library for tensor primitives
+   :description: installation instructions for the hipTensor library
    :keywords: hipTensor, ROCm, library, API, tool, installation
 
 .. _installation:
 
-===============================
-Installation
-===============================
+*********************************
+Installing and building hipTensor
+*********************************
 
-The quickest way to install is using prebuilt packages that are released with ROCm.
-Alternatively, there are instructions to build from source.
+The quickest way to install hipTensor is to use the prebuilt packages that are released with ROCm.
+Alternatively, this topic includes instructions to build from source.
 
-Available ROCm packages are:
+The available ROCm packages are:
 
-* hiptensor (library + header files for development).
-* hiptensor-dev (library development package).
-* hiptensor-samples (sample executables).
-* hiptensor-tests (test executables).
-* hiptensor-clients (samples and test executables).
+*  hiptensor (library and header files for development)
+*  hiptensor-dev (library development package)
+*  hiptensor-samples (sample executables)
+*  hiptensor-tests (test executables)
+*  hiptensor-clients (samples and test executables)
 
--------------
 Prerequisites
--------------
+=============
 
-* A ROCm 6.0 enabled platform. More information at `ROCm Github <https://github.com/ROCm/ROCm>`_.
+hipTensor requires a ROCm-enabled platform, using ROCm version 6.4 or later.
+For more information, see :doc:`ROCm installation <rocm-install-on-linux:index>`
+and the `ROCm GitHub <https://github.com/ROCm/ROCm>`_.
 
------------------------------
-Installing pre-built packages
------------------------------
+Installing prebuilt packages
+============================
 
-To install hipTensor on Ubuntu or Debian, use:
+To install hipTensor on Ubuntu or Debian, use these commands:
 
-::
+.. code-block:: shell
 
    sudo apt-get update
    sudo apt-get install hiptensor hiptensor-dev hiptensor-samples hiptensor-tests
 
-To install hipTensor on CentOS, use:
+To install hipTensor on RHEL-based systems, use:
 
-::
+.. code-block:: shell
 
-    sudo yum update
-    sudo yum install hiptensor hiptensor-dev hiptensor-samples hiptensor-tests
+   sudo yum update
+   sudo yum install hiptensor hiptensor-dev hiptensor-samples hiptensor-tests
 
 To install hipTensor on SLES, use:
 
-::
+.. code-block:: shell
 
-    sudo dnf upgrade
-    sudo dnf install hiptensor hiptensor-dev hiptensor-samples hiptensor-tests
+   sudo dnf upgrade
+   sudo dnf install hiptensor hiptensor-dev hiptensor-samples hiptensor-tests
 
-Once installed, hipTensor can be used just like any other library with a C++ API.
+After hipTensor is installed, it can be used just like any other library with a C++ API.
 
----------------------------------
-Building and installing hipTensor
----------------------------------
+Building and installing hipTensor from source
+=============================================
 
-For most users building from source is not necessary, as hipTensor can be used after installing the pre-built
-packages as described above. If still desired, here are the instructions to build hipTensor from source:
+It isn't necessary to build hipTensor from source because it's ready to use after installing
+the prebuilt packages, as described above.
+To build hipTensor from source, follow the instructions in this section.
 
 System requirements
-^^^^^^^^^^^^^^^^^^^
-As a general rule, 8GB of system memory is required for a full hipTensor build. This value can be lower if hipTensor is built without tests. This value may also increase in the future as more functions are added.
+-------------------------------------------
+
+8GB of system memory is required for a full hipTensor build.
+This value might be lower if hipTensor is built without tests.
 
 GPU support
-^^^^^^^^^^^
-AMD CDNA class GPU featuring matrix core support: `gfx908`, `gfx90a`, `gfx942`, `gfx950` labeled as `gfx9`.
+-------------------------------------------
+
+hipTensor is supported on the AMD CDNA class GPUs featuring matrix core support,
+including the gfx908, gfx90a, gfx942, and gfx950 GPUs (collectively labeled as gfx9).
 
 .. note::
-    Double precision FP64 datatype support requires `gfx90a`, `gfx942` or `gfx950`.
+
+   Double precision ``FP64`` datatype support requires the gfx90a, gfx942, or gfx950.
 
 Dependencies
-^^^^^^^^^^^^
-hipTensor is designed to have minimal external dependencies such that it is light-weight and portable.
+-------------------------------------------
+
+hipTensor is designed to have minimal external dependencies so it's lightweight and portable.
+The following dependencies are required:
 
 .. <!-- spellcheck-disable -->
 
-* Minimum ROCm version support is 6.4.
-* Minimum cmake version support is 3.14.
-* Minimum ROCm-cmake version support is 0.8.0.
-* Minimum HIP runtime version support is 4.3.0 (or ROCm package ROCm hip-runtime-amd).
-* Minimum LLVM dev package version support is 7.0 (available as ROCm package rocm-llvm-dev).
-* Hiptensor leverages the amd-master branch of the composable kernel, a stable and widely adopted version for development.
+*  `ROCm <https://github.com/ROCm/ROCm>`_ (Version 6.4 or later)
+*  `CMake <https://cmake.org/>`_ (Version 3.14 or later)
+*  `rocm-cmake <https://github.com/ROCm/rocm-cmake>`_ (Version 0.8.0 or later)
+*  `HIP runtime <https://github.com/ROCm/hip>`_ (Version 6.4.0 or later) (Or the ROCm hip-runtime-amd package)
+*  LLVM dev package (Version 7.0 or later) (Also available as the ROCm rocm-llvm-dev package)
+*  `composable kernel <https://github.com/ROCm/composable_kernel>`_ (hipTensor uses the amd-master branch, which is a stable and widely adopted version for development.)
 
 .. <!-- spellcheck-enable -->
 
 .. note::
 
-    It is best to use available ROCm packages from the same release where applicable.
+   It's best to use ROCm packages from the same release where applicable.
 
-Download hipTensor
-^^^^^^^^^^^^^^^^^^
+Downloading hipTensor
+-------------------------------------------
 
-The hipTensor source code is available on `hipTensor Github <https://github.com/ROCmSoftwarePlatform/hipTensor>`_. hipTensor has a minimum ROCm support version 6.4.
-To check the ROCm Version on your system, use:
+The hipTensor source code is available from the `hipTensor GitHub <https://github.com/ROCm/hipTensor>`_.
+ROCm version 6.4 or later is required.
 
-::
+To verify the ROCm version installed on an Ubuntu system, use this command:
 
-    apt show rocm-libs -a
+.. code-block:: shell
 
-For Centos use
+   apt show rocm-libs -a
 
-::
+For RHEL-related systems, use:
 
-    yum info rocm-libs
+.. code-block:: shell
 
-The ROCm version has major, minor, and patch fields, possibly followed by a build specific identifier. For example, a ROCm version 4.0.0.40000-23 corresponds to major = 4, minor = 0, patch = 0, and build identifier 40000-23.
-There are GitHub branches at the hipTensor site with names ``rocm-major.minor.x`` where major and minor are the same as in the ROCm version. To download hipTensor on ROCm version 4.0.0.40000-23, use:
+   yum info rocm-libs
 
-::
+The ROCm version has major, minor, and patch fields, possibly followed by a build-specific identifier.
+For example, a ROCm version of ``4.0.0.40000-23`` corresponds to major release = ``4``, minor release = ``0``,
+patch = ``0``, and build identifier ``40000-23``.
+The hipTensor GitHub has branches with names like ``rocm-major.minor.x``,
+where ``major`` and ``minor`` are the same as for the ROCm version.
+To download hipTensor on ROCm version `x.y`, use this command:
 
-   git clone -b release/rocm-rel-x.y https://github.com/ROCmSoftwarePlatform/hipTensor.git
+.. code-block:: shell
+
+   git clone -b release/rocm-rel-x.y https://github.com/ROCm/hipTensor.git
    cd hipTensor
 
-Replace ``x.y`` in the above command with the version of ROCm installed on your machine. For example, if you have ROCm 5.0 installed, then replace release/rocm-rel-x.y with release/rocm-rel-5.0.
-
-Build documentation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To build documentation locally, run:
-
-.. code-block:: bash
-
-    cd docs
-
-    sudo apt-get update
-    sudo apt-get install doxygen
-    sudo apt-get install texlive-latex-base texlive-latex-extra
-
-    pip3 install -r sphinx/requirements.txt
-
-    python3 -m sphinx -T -E -b latex -d _build/doctrees -D language=en . _build/latex
-
-    cd _build/latex
-
-    pdflatex hiptensor.tex
-
-Running the above commands generates ``hiptensor.pdf``. Alternatively, the latest docs build can be found at `hipTensor docs <https://rocm.docs.amd.com/projects/hipTensor/en/latest/index.html>`_.
+Replace ``x.y`` in the above command with the version of ROCm installed on your machine.
+For example, if you have ROCm 6.4 installed, then replace ``release/rocm-rel-x.y`` with ``release/rocm-rel-6.4``.
 
 Build configuration
-^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------------
 
-You can choose to build any of the following:
+You can choose to build any of the following combinations:
 
-* library only
-* library and samples
-* library and tests
-* library, samples and tests
+* The hipTensor library only
+* The library and samples
+* The library and tests
+* The library, samples, and tests
 
-You only need the hipTensor library for calling and linking to hipTensor API from your code.
-The clients contain the tests and sample codes.
+You only need the hipTensor library to call and link to hipTensor API from your code.
+The clients contain the tests and sample code.
 
-Below are the project options available to build hipTensor library with or without clients.
+Here are the available options to build the hipTensor library, with or without clients.
 
 .. list-table::
 
     *   -   **Option**
         -   **Description**
-        -   **Default Value**
-    *   -   GPU_TARGETS
-        -   Build code for specific GPU target(s)
+        -   **Default value**
+    *   -   ``GPU_TARGETS``
+        -   Build the code for specific GPU target(s)
         -   ``gfx908``; ``gfx90a``; ``gfx942``; ``gfx950``
-    *   -   HIPTENSOR_BUILD_TESTS
-        -   Build Tests
-        -   ON
-    *   -   HIPTENSOR_BUILD_SAMPLES
-        -   Build Samples
-        -   ON
-    *   -   HIPTENSOR_BUILD_COMPRESSED_DBG
+    *   -   ``HIPTENSOR_BUILD_TESTS``
+        -   Build the tests
+        -   ``ON``
+    *   -   ``HIPTENSOR_BUILD_SAMPLES``
+        -   Build the samples
+        -   ``ON``
+    *   -   ``HIPTENSOR_BUILD_COMPRESSED_DBG``
         -   Enable compressed debug symbols
-        -   ON
-    *   -   HIPTENSOR_DATA_LAYOUT_COL_MAJOR
-        -   Set hiptensor default data layout to column major
-        -   ON
+        -   ``ON``
+    *   -   ``HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR``
+        -   Set the hipTensor default data layout to column major
+        -   ``ON``
 
 Here are some example project configurations:
 
-.. tabularcolumns::
-   |\X{1}{4}|\X{3}{4}|
+.. csv-table::
+   :header: "Configuration","Command"
+   :widths: 20, 110
 
-+-----------------------------------+--------------------------------------------------------------------------------------------------------------------+
-|         Configuration             |                                          Command                                                                   |
-+===================================+====================================================================================================================+
-|            Basic                  | :code:`CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> .`                               |
-+-----------------------------------+--------------------------------------------------------------------------------------------------------------------+
-|        Targeting gfx908           | :code:`CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> . -DGPU_TARGETS=gfx908`          |
-+-----------------------------------+--------------------------------------------------------------------------------------------------------------------+
-|          Debug build              | :code:`CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> . -DCMAKE_BUILD_TYPE=Debug`      |
-+-----------------------------------+--------------------------------------------------------------------------------------------------------------------+
+   "Basic", "``CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> .``"
+   "Targeting gfx908", "``CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> . -DGPU_TARGETS=gfx908``"
+   "Debug build", "``CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> . -DCMAKE_BUILD_TYPE=Debug``"
 
-Build library
-^^^^^^^^^^^^^^^^^^
+Building the library alone
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, the project is configured in Release mode.
+By default, the project is configured for Release mode.
 
-To build the library alone, run:
+To build the library alone, run this command:
 
 .. code-block:: bash
 
-    CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B <build_dir> . -DHIPTENSOR_BUILD_TESTS=OFF -DHIPTENSOR_BUILD_SAMPLES=OFF
+   CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B <build_dir> . -DHIPTENSOR_BUILD_TESTS=OFF -DHIPTENSOR_BUILD_SAMPLES=OFF
 
-After configuration, build using:
+After configuration, build the library using this command:
 
 .. code-block:: bash
 
-    cmake --build <build_dir> -- -j<nproc>
+   cmake --build <build_dir> -- -j<nproc>
 
 .. note::
-    We recommend using a minimum of 16 threads to build hipTensor with any tests (-j16).
+   
+   It's recommended to use a minimum of 16 threads to build hipTensor with any tests, for example, using ``-j16``.
 
-Build library and samples
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Building the library and samples
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To build library and samples, run:
-
-.. code-block:: bash
-
-    CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B <build_dir> . -DHIPTENSOR_BUILD_TESTS=OFF -DHIPTENSOR_BUILD_SAMPLES=ON
-
-After configuration, build using:
+To build the library and samples, run the following command:
 
 .. code-block:: bash
 
-    cmake --build <build_dir> -- -j<nproc>
+   CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B <build_dir> . -DHIPTENSOR_BUILD_TESTS=OFF -DHIPTENSOR_BUILD_SAMPLES=ON
 
-The samples folder in ``<build_dir>`` contains executables in the table below.
+After configuration, build the library using this command:
+
+.. code-block:: bash
+
+   cmake --build <build_dir> -- -j<nproc>
+
+The samples folder in ``<build_dir>`` contains the executables in the table below.
 
 .. tabularcolumns::
    |\X{2}{4}|\X{2}{4}|
 
-================================================================== =====================================================================================================================================================================
-Executable Name                                                    Description
-================================================================== =====================================================================================================================================================================
-``simple_bilinear_contraction_bf16_bf16_bf16_bf16_compute_bf16``   A simple bilinear contraction [D = alpha * (A x B) + beta * C] using half-precision brain float inputs, output and compute types
-``simple_bilinear_contraction_f16_f16_f16_f16_compute_f16``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using half-precision floating point inputs, output and compute types
-``simple_bilinear_contraction_f32_f32_f32_f32_compute_bf16``       A simple bilinear contraction [D = alpha * (A x B) + beta * C] using single-precision floating point input and output, half-precision brain float compute types
-``simple_bilinear_contraction_f32_f32_f32_f32_compute_f16``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using single-precision floating point input and output, half-precision floating point compute types
-``simple_bilinear_contraction_f32_f32_f32_f32_compute_f32``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using single-precision floating point input, output and compute types
-``simple_bilinear_contraction_cf32_cf32_cf32_cf32_compute_cf32``   A simple bilinear contraction [D = alpha * (A x B) + beta * C] using complex single-precision floating point input, output and compute types
-``simple_bilinear_contraction_f64_f64_f64_f64_compute_f32``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using double-precision floating point input, output and single precision floating point compute types
-``simple_bilinear_contraction_f64_f64_f64_f64_compute_f64``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using double-precision floating point input, output and compute types
-``simple_scale_contraction_bf16_bf16_bf16_compute_bf16``           A simple scale contraction [D = alpha * (A x B) ] using half-precision brain float inputs, output and compute types
-``simple_scale_contraction_f16_f16_f16_compute_f16``               A simple scale contraction [D = alpha * (A x B) ] using half-precision floating point inputs, output and compute types
-``simple_scale_contraction_f32_f32_f32_compute_bf16``              A simple scale contraction [D = alpha * (A x B) ] using single-precision floating point input and output, half-precision brain float compute types
-``simple_scale_contraction_f32_f32_f32_compute_f16``               A simple scale contraction [D = alpha * (A x B) ] using single-precision floating point input and output, half-precision floating point compute types
-``simple_scale_contraction_f32_f32_f32_compute_f32``               A simple scale contraction [D = alpha * (A x B) ] using single-precision floating point input, output and compute types
-``simple_scale_contraction_cf32_cf32_cf32_compute_cf32``           A simple scale contraction [D = alpha * (A x B) ] using complex single-precision floating point input, output and compute types
-``simple_scale_contraction_f64_f64_f64_compute_f32``               A simple scale contraction [D = alpha * (A x B) ] using double-precision floating point input, output and single precision floating point compute types
-``simple_scale_contraction_f64_f64_f64_compute_f64``               A simple scale contraction [D = alpha * (A x B) ] using double-precision floating point input, output and compute types
+================================================================== =======================================================================================================================================================================
+Executable name                                                    Description
+================================================================== =======================================================================================================================================================================
+``simple_bilinear_contraction_bf16_bf16_bf16_bf16_compute_bf16``   A simple bilinear contraction [D = alpha * (A x B) + beta * C] using half-precision brain float inputs, output, and compute types
+``simple_bilinear_contraction_f16_f16_f16_f16_compute_f16``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using half-precision floating point inputs, output, and compute types
+``simple_bilinear_contraction_f32_f32_f32_f32_compute_bf16``       A simple bilinear contraction [D = alpha * (A x B) + beta * C] using single-precision floating point input and output, and half-precision brain float compute types
+``simple_bilinear_contraction_f32_f32_f32_f32_compute_f16``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using single-precision floating point input and output, and half-precision floating point compute types
+``simple_bilinear_contraction_f32_f32_f32_f32_compute_f32``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using single-precision floating point input, output, and compute types
+``simple_bilinear_contraction_cf32_cf32_cf32_cf32_compute_cf32``   A simple bilinear contraction [D = alpha * (A x B) + beta * C] using complex single-precision floating point input, output, and compute types
+``simple_bilinear_contraction_f64_f64_f64_f64_compute_f32``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using double-precision floating point input and output and single-precision floating point compute types
+``simple_bilinear_contraction_f64_f64_f64_f64_compute_f64``        A simple bilinear contraction [D = alpha * (A x B) + beta * C] using double-precision floating point input, output, and compute types
+``simple_scale_contraction_bf16_bf16_bf16_compute_bf16``           A simple scale contraction [D = alpha * (A x B) ] using half-precision brain float inputs, output, and compute types
+``simple_scale_contraction_f16_f16_f16_compute_f16``               A simple scale contraction [D = alpha * (A x B) ] using half-precision floating point inputs, output, and compute types
+``simple_scale_contraction_f32_f32_f32_compute_bf16``              A simple scale contraction [D = alpha * (A x B) ] using single-precision floating point input and output and half-precision brain float compute types
+``simple_scale_contraction_f32_f32_f32_compute_f16``               A simple scale contraction [D = alpha * (A x B) ] using single-precision floating point input and output and half-precision floating point compute types
+``simple_scale_contraction_f32_f32_f32_compute_f32``               A simple scale contraction [D = alpha * (A x B) ] using single-precision floating point input, output, and compute types
+``simple_scale_contraction_cf32_cf32_cf32_compute_cf32``           A simple scale contraction [D = alpha * (A x B) ] using complex single-precision floating point input, output, and compute types
+``simple_scale_contraction_f64_f64_f64_compute_f32``               A simple scale contraction [D = alpha * (A x B) ] using double-precision floating point input and output and single-precision floating point compute types
+``simple_scale_contraction_f64_f64_f64_compute_f64``               A simple scale contraction [D = alpha * (A x B) ] using double-precision floating point input, output, and compute types
 ``simple_permutation``                                             A simple permutation using single-precision floating point input and output types
+``simple_elementwise_binary``                                      A simple element-wise binary operation using single-precision floating point input and output types
+``simple_elementwise_trinary``                                     A simple element-wise trinary operation using single-precision floating point input and output types
 ``simple_reduction``                                               A simple reduction using single-precision floating point input and output types
-================================================================== =====================================================================================================================================================================
+================================================================== =======================================================================================================================================================================
 
-Build library and tests
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Building the library and tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To build library and tests, run:
-
-.. code-block:: bash
-
-    CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B <build_dir> . -DHIPTENSOR_BUILD_TESTS=ON -DHIPTENSOR_BUILD_SAMPLES=OFF
-
-After configuration, build using:
+To build the library and tests, run the following command:
 
 .. code-block:: bash
 
-    cmake --build <build_dir> -- -j<nproc>
+   CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B <build_dir> . -DHIPTENSOR_BUILD_TESTS=ON -DHIPTENSOR_BUILD_SAMPLES=OFF
 
-The tests in ``<build_dir>`` contain executables as given in the table below.
+After configuration, build using this command:
+
+.. code-block:: bash
+
+   cmake --build <build_dir> -- -j<nproc>
+
+The tests in ``<build_dir>`` contain executables, as shown in the table below.
 
 .. tabularcolumns::
    |\X{2}{4}|\X{2}{4}|
@@ -277,232 +266,265 @@ Executable name                                  Description
 ================================================ ===========================================================================================================================
 ``logger_test``                                  Unit test to validate hipTensor Logger APIs
 ``yaml_test``                                    Unit test to validate the YAML functionality used to bundle and run test suites
-``bilinear_contraction_test_m1n1k1``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with  half, single and mixed precision datatypes of rank 2
-``bilinear_contraction_test_m2n2k2``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with  half, single and mixed precision datatypes of rank 4
-``bilinear_contraction_test_m3n3k3``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with  half, single and mixed precision datatypes of rank 6
-``bilinear_contraction_test_m4n4k4``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with  half, single and mixed precision datatypes of rank 8
-``bilinear_contraction_test_m5n5k5``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with  half, single and mixed precision datatypes of rank 10
-``bilinear_contraction_test_m6n6k6``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with  half, single and mixed precision datatypes of rank 12
-``complex_bilinear_contraction_test_m1n2k1``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with  complex single and double precision datatypes of rank 2
-``complex_bilinear_contraction_test_m2n2k2``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with  complex single and double precision datatypes of rank 4
-``complex_bilinear_contraction_test_m3n3k3``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with  complex single and double precision datatypes of rank 6
-``complex_bilinear_contraction_test_m4n4k4``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with  complex single and double precision datatypes of rank 8
-``complex_bilinear_contraction_test_m5n5k5``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with  complex single and double precision datatypes of rank 10
-``complex_bilinear_contraction_test_m6n6k6``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with  complex single and double precision datatypes of rank 12
-``scale_contraction_test_m1n1k1``                Scale contraction test [D = alpha * (A x B)] with  half, single and mixed precision datatypes of rank 2
-``scale_contraction_test_m2n2k2``                Scale contraction test [D = alpha * (A x B)] with  half, single and mixed precision datatypes of rank 4
-``scale_contraction_test_m3n3k3``                Scale contraction test [D = alpha * (A x B)] with  half, single and mixed precision datatypes of rank 6
-``scale_contraction_test_m4n4k4``                Scale contraction test [D = alpha * (A x B)] with  half, single and mixed precision datatypes of rank 8
-``scale_contraction_test_m5n5k5``                Scale contraction test [D = alpha * (A x B)] with  half, single and mixed precision datatypes of rank 10
-``scale_contraction_test_m6n6k6``                Scale contraction test [D = alpha * (A x B)] with  half, single and mixed precision datatypes of rank 12
-``complex_scale_contraction_test_m1n1k1``        Scale contraction test [D = alpha * (A x B)] with  complex single and double precision datatypes of rank 2
-``complex_scale_contraction_test_m2n2k2``        Scale contraction test [D = alpha * (A x B)] with  complex single and double precision datatypes of rank 4
-``complex_scale_contraction_test_m3n3k3``        Scale contraction test [D = alpha * (A x B)] with  complex single and double precision datatypes of rank 6
-``complex_scale_contraction_test_m4n4k4``        Scale contraction test [D = alpha * (A x B)] with  complex single and double precision datatypes of rank 8
-``complex_scale_contraction_test_m5n5k5``        Scale contraction test [D = alpha * (A x B)] with  complex single and double precision datatypes of rank 10
-``complex_scale_contraction_test_m6n6k6``        Scale contraction test [D = alpha * (A x B)] with  complex single and double precision datatypes of rank 12
+``bilinear_contraction_test_m1n1k1``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with half, single, and mixed precision datatypes of rank 2
+``bilinear_contraction_test_m2n2k2``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with half, single, and mixed precision datatypes of rank 4
+``bilinear_contraction_test_m3n3k3``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with half, single, and mixed precision datatypes of rank 6
+``bilinear_contraction_test_m4n4k4``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with half, single, and mixed precision datatypes of rank 8
+``bilinear_contraction_test_m5n5k5``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with half, single, and mixed precision datatypes of rank 10
+``bilinear_contraction_test_m6n6k6``             Bilinear contraction test [D = alpha * (A x B) + beta * C] with half, single, and mixed precision datatypes of rank 12
+``complex_bilinear_contraction_test_m1n2k1``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with complex single and double precision datatypes of rank 2
+``complex_bilinear_contraction_test_m2n2k2``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with complex single and double precision datatypes of rank 4
+``complex_bilinear_contraction_test_m3n3k3``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with complex single and double precision datatypes of rank 6
+``complex_bilinear_contraction_test_m4n4k4``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with complex single and double precision datatypes of rank 8
+``complex_bilinear_contraction_test_m5n5k5``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with complex single and double precision datatypes of rank 10
+``complex_bilinear_contraction_test_m6n6k6``     Bilinear contraction test [D = alpha * (A x B) + beta * C] with complex single and double precision datatypes of rank 12
+``scale_contraction_test_m1n1k1``                Scale contraction test [D = alpha * (A x B)] with half, single, and mixed precision datatypes of rank 2
+``scale_contraction_test_m2n2k2``                Scale contraction test [D = alpha * (A x B)] with half, single, and mixed precision datatypes of rank 4
+``scale_contraction_test_m3n3k3``                Scale contraction test [D = alpha * (A x B)] with half, single, and mixed precision datatypes of rank 6
+``scale_contraction_test_m4n4k4``                Scale contraction test [D = alpha * (A x B)] with half, single, and mixed precision datatypes of rank 8
+``scale_contraction_test_m5n5k5``                Scale contraction test [D = alpha * (A x B)] with half, single, and mixed precision datatypes of rank 10
+``scale_contraction_test_m6n6k6``                Scale contraction test [D = alpha * (A x B)] with half, single, and mixed precision datatypes of rank 12
+``complex_scale_contraction_test_m1n1k1``        Scale contraction test [D = alpha * (A x B)] with complex single and double precision datatypes of rank 2
+``complex_scale_contraction_test_m2n2k2``        Scale contraction test [D = alpha * (A x B)] with complex single and double precision datatypes of rank 4
+``complex_scale_contraction_test_m3n3k3``        Scale contraction test [D = alpha * (A x B)] with complex single and double precision datatypes of rank 6
+``complex_scale_contraction_test_m4n4k4``        Scale contraction test [D = alpha * (A x B)] with complex single and double precision datatypes of rank 8
+``complex_scale_contraction_test_m5n5k5``        Scale contraction test [D = alpha * (A x B)] with complex single and double precision datatypes of rank 10
+``complex_scale_contraction_test_m6n6k6``        Scale contraction test [D = alpha * (A x B)] with complex single and double precision datatypes of rank 12
 ``rank2_permutation_test``                       Permutation test with half and single precision datatypes of rank 2
 ``rank3_permutation_test``                       Permutation test with half and single precision datatypes of rank 3
 ``rank4_permutation_test``                       Permutation test with half and single precision datatypes of rank 4
 ``rank5_permutation_test``                       Permutation test with half and single precision datatypes of rank 5
 ``rank6_permutation_test``                       Permutation test with half and single precision datatypes of rank 6
-``rank1_reduction_test``                         Reduction test with half, single and double precision datatypes of rank 1
-``rank2_reduction_test``                         Reduction test with half, single and double precision datatypes of rank 2
-``rank3_reduction_test``                         Reduction test with half, single and double precision datatypes of rank 3
-``rank4_reduction_test``                         Reduction test with half, single and double precision datatypes of rank 4
-``rank5_reduction_test``                         Reduction test with half, single and double precision datatypes of rank 5
-``rank6_reduction_test``                         Reduction test with half, single and double precision datatypes of rank 6
+``rank2_elementwise_binary_op_test``             Element-wise binary operation test with half, single, and double precision datatypes of rank 2
+``rank3_elementwise_binary_op_test``             Element-wise binary operation test with half, single, and double precision datatypes of rank 3
+``rank4_elementwise_binary_op_test``             Element-wise binary operation test with half, single, and double precision datatypes of rank 4
+``rank5_elementwise_binary_op_test``             Element-wise binary operation test with half, single, and double precision datatypes of rank 5
+``rank6_elementwise_binary_op_test``             Element-wise binary operation test with half, single, and double precision datatypes of rank 6
+``rank2_elementwise_trinary_op_test``            Element-wise trinary operation test with half, single, and double precision datatypes of rank 2
+``rank3_elementwise_trinary_op_test``            Element-wise trinary operation test with half, single, and double precision datatypes of rank 3
+``rank4_elementwise_trinary_op_test``            Element-wise trinary operation test with half, single, and double precision datatypes of rank 4
+``rank5_elementwise_trinary_op_test``            Element-wise trinary operation test with half, single, and double precision datatypes of rank 5
+``rank6_elementwise_trinary_op_test``            Element-wise trinary operation test with half, single, and double precision datatypes of rank 6
+``rank1_reduction_test``                         Reduction test with half, single, and double precision datatypes of rank 1
+``rank2_reduction_test``                         Reduction test with half, single, and double precision datatypes of rank 2
+``rank3_reduction_test``                         Reduction test with half, single, and double precision datatypes of rank 3
+``rank4_reduction_test``                         Reduction test with half, single, and double precision datatypes of rank 4
+``rank5_reduction_test``                         Reduction test with half, single, and double precision datatypes of rank 5
+``rank6_reduction_test``                         Reduction test with half, single, and double precision datatypes of rank 6
 ================================================ ===========================================================================================================================
 
 Make targets list
 ^^^^^^^^^^^^^^^^^
 
-When building hipTensor during the ``make`` step, we can specify make targets instead of defaulting ``make all``. The following table highlights relationships between high level grouped targets and individual targets.
+When building hipTensor during the ``make`` step, you can specify the Make targets instead of defaulting to ``make all``.
+The following table highlights the relationships between high-level grouped targets and individual targets.
 
-.. tabularcolumns::
-   |\X{1}{4}|\X{3}{4}|
 
-+-----------------------------------+-----------------------------------------------------------------------------+
-|           Group Target            |            Individual Targets                                               |
-+===================================+=============================================================================+
-|                                   |simple_bilinear_contraction_bf16_bf16_bf16_bf16_compute_bf16                 |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_bilinear_contraction_f16_f16_f16_f16_compute_f16                      |
-|                                   +-----------------------------------------------------------------------------+
-| hiptensor_samples                 |simple_bilinear_contraction_f32_f32_f32_f32_compute_bf16                     |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_bilinear_contraction_f32_f32_f32_f32_compute_f16                      |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_bilinear_contraction_f32_f32_f32_f32_compute_f32                      |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_bilinear_contraction_cf32_cf32_cf32_cf32_compute_cf32                 |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_bilinear_contraction_f64_f64_f64_f64_compute_f32                      |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_bilinear_contraction_f64_f64_f64_f64_compute_f64                      |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_scale_contraction_bf16_bf16_bf16_compute_bf16                         |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_scale_contraction_f16_f16_f16_compute_f16                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_scale_contraction_f32_f32_f32_compute_bf16                            |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_scale_contraction_f32_f32_f32_compute_f16                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_scale_contraction_f32_f32_f32_compute_f32                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_scale_contraction_cf32_cf32_cf32_compute_cf32                         |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_scale_contraction_f64_f64_f64_compute_f32                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_scale_contraction_f64_f64_f64_compute_f64                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |simple_permutation                                                           |
-|                                   |simple_reduction                                                             |
-+-----------------------------------+-----------------------------------------------------------------------------+
-|                                   |logger_test                                                                  |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |yaml_test                                                                    |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |bilinear_contraction_test_m1n1k1                                             |
-|                                   +-----------------------------------------------------------------------------+
-| hiptensor_tests                   |bilinear_contraction_test_m2n2k2                                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |bilinear_contraction_test_m3n3k3                                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |bilinear_contraction_test_m4n4k4                                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |bilinear_contraction_test_m5n5k5                                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |bilinear_contraction_test_m6n6k6                                             |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_bilinear_contraction_test_m1n1k1                                     |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_bilinear_contraction_test_m2n2k2                                     |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_bilinear_contraction_test_m3n3k3                                     |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_bilinear_contraction_test_m4n4k4                                     |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_bilinear_contraction_test_m5n5k5                                     |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_bilinear_contraction_test_m6n6k6                                     |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |scale_contraction_test_m1n1k1                                                |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |scale_contraction_test_m2n2k2                                                |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |scale_contraction_test_m3n3k3                                                |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |scale_contraction_test_m4n4k4                                                |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |scale_contraction_test_m5n5k5                                                |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |scale_contraction_test_m6n6k6                                                |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_scale_contraction_test_m1n1k1                                        |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_scale_contraction_test_m2n2k2                                        |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_scale_contraction_test_m3n3k3                                        |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_scale_contraction_test_m4n4k4                                        |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_scale_contraction_test_m5n5k5                                        |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |complex_scale_contraction_test_m6n6k6                                        |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank2_permutation_test                                                       |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank3_permutation_test                                                       |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank4_permutation_test                                                       |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank5_permutation_test                                                       |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank6_permutation_test                                                       |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank1_reduction_test                                                         |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank2_reduction_test                                                         |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank3_reduction_test                                                         |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank4_reduction_test                                                         |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank5_reduction_test                                                         |
-|                                   +-----------------------------------------------------------------------------+
-|                                   |rank6_reduction_test                                                         |
-+-----------------------------------+-----------------------------------------------------------------------------+
++-----------------------------------+---------------------------------------------------------------------------------+
+|           Group target            |            Individual targets                                                   |
++===================================+=================================================================================+
+|                                   |``simple_bilinear_contraction_bf16_bf16_bf16_bf16_compute_bf16``                 |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_bilinear_contraction_f16_f16_f16_f16_compute_f16``                      |
+|                                   +---------------------------------------------------------------------------------+
+| ``hiptensor_samples``             |``simple_bilinear_contraction_f32_f32_f32_f32_compute_bf16``                     |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_bilinear_contraction_f32_f32_f32_f32_compute_f16``                      |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_bilinear_contraction_f32_f32_f32_f32_compute_f32``                      |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_bilinear_contraction_cf32_cf32_cf32_cf32_compute_cf32``                 |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_bilinear_contraction_f64_f64_f64_f64_compute_f32``                      |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_bilinear_contraction_f64_f64_f64_f64_compute_f64``                      |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_scale_contraction_bf16_bf16_bf16_compute_bf16``                         |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_scale_contraction_f16_f16_f16_compute_f16``                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_scale_contraction_f32_f32_f32_compute_bf16``                            |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_scale_contraction_f32_f32_f32_compute_f16``                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_scale_contraction_f32_f32_f32_compute_f32``                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_scale_contraction_cf32_cf32_cf32_compute_cf32``                         |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_scale_contraction_f64_f64_f64_compute_f32``                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_scale_contraction_f64_f64_f64_compute_f64``                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_permutation``                                                           |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_elementwise_binary``                                                    |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_elementwise_trinary``                                                   |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``simple_reduction``                                                             |
++-----------------------------------+---------------------------------------------------------------------------------+
+|                                   |``logger_test``                                                                  |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``yaml_test``                                                                    |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``bilinear_contraction_test_m1n1k1``                                             |
+|                                   +---------------------------------------------------------------------------------+
+| ``hiptensor_tests``               |``bilinear_contraction_test_m2n2k2``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``bilinear_contraction_test_m3n3k3``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``bilinear_contraction_test_m4n4k4``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``bilinear_contraction_test_m5n5k5``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``bilinear_contraction_test_m6n6k6``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_bilinear_contraction_test_m1n1k1``                                     |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_bilinear_contraction_test_m2n2k2``                                     |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_bilinear_contraction_test_m3n3k3``                                     |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_bilinear_contraction_test_m4n4k4``                                     |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_bilinear_contraction_test_m5n5k5``                                     |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_bilinear_contraction_test_m6n6k6``                                     |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``scale_contraction_test_m1n1k1``                                                |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``scale_contraction_test_m2n2k2``                                                |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``scale_contraction_test_m3n3k3``                                                |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``scale_contraction_test_m4n4k4``                                                |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``scale_contraction_test_m5n5k5``                                                |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``scale_contraction_test_m6n6k6``                                                |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_scale_contraction_test_m1n1k1``                                        |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_scale_contraction_test_m2n2k2``                                        |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_scale_contraction_test_m3n3k3``                                        |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_scale_contraction_test_m4n4k4``                                        |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_scale_contraction_test_m5n5k5``                                        |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``complex_scale_contraction_test_m6n6k6``                                        |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank2_permutation_test``                                                       |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank3_permutation_test``                                                       |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank4_permutation_test``                                                       |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank5_permutation_test``                                                       |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank6_permutation_test``                                                       |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank2_elementwise_binary_op_test``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank3_elementwise_binary_op_test``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank4_elementwise_binary_op_test``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank5_elementwise_binary_op_test``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank6_elementwise_binary_op_test``                                             |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank2_elementwise_trinary_op_test``                                            |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank3_elementwise_trinary_op_test``                                            |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank4_elementwise_trinary_op_test``                                            |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank5_elementwise_trinary_op_test``                                            |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank6_elementwise_trinary_op_test``                                            |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank1_reduction_test``                                                         |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank2_reduction_test``                                                         |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank3_reduction_test``                                                         |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank4_reduction_test``                                                         |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank5_reduction_test``                                                         |
+|                                   +---------------------------------------------------------------------------------+
+|                                   |``rank6_reduction_test``                                                         |
++-----------------------------------+---------------------------------------------------------------------------------+
 
 Benchmarking scripts
-^^^^^^^^^^^^^^^^^^^^
+-------------------------------------------
 
-Benchmarking scripts located at ``<project root>/scripts/performance/``
+The benchmarking scripts are located at ``<project root>/scripts/performance/``.
 
-.. tabularcolumns::
-   |\X{2}{4}|\X{2}{4}|
+.. csv-table::
+   :header: "Script name","Description"
+   :widths: 40, 60
 
-================================================================== =====================================================================================================================================================================
-Script Name                                                        Description
-================================================================== =====================================================================================================================================================================
-``BenchmarkContraction.sh``                                        Benchmarking script for contraction
-``BenchmarkPermutation.sh``                                        Benchmarking script for permutation
-``BenchmarkReduction.sh``                                          Benchmarking script for reduction
-================================================================== =====================================================================================================================================================================
+   "``BenchmarkContraction.sh``", "Benchmarking script for contraction"
+   "``BenchmarkPermutation.sh``", "Benchmarking script for permutation"
+   "``BenchmarkReduction.sh``", "Benchmarking script for reduction"
 
 Build performance
-^^^^^^^^^^^^^^^^^
+-------------------------------------------
 
-Depending on the resources available to the build machine and the build configuration selected, hipTensor build times can be on the order of an hour or more. Here are some things you can do to reduce build times:
+Depending on the resources available to the build machine and the selected build configuration,
+hipTensor build times can take an hour or more. Here are some things you can do to reduce build times:
 
-* Target a specific GPU (e.g., ``-D GPU_TARGETS=gfx908``)
-* Use lots of threads (e.g., ``-j32``)
-* If they aren't needed, specify either ``HIPTENSOR_BUILD_TESTS`` or ``HIPTENSOR_BUILD_SAMPLES`` as OFF to disable client builds.
-* During the ``make`` command, build a specific target, e.g: ``logger_test``.
+*  Target a specific GPU, for instance, with ``-D GPU_TARGETS=gfx908``.
+*  Use a large number of threads, for instance, ``-j32``.
+*  If the client builds aren't needed, specify ``HIPTENSOR_BUILD_TESTS`` or ``HIPTENSOR_BUILD_SAMPLES`` as ``OFF`` to disable them.
+*  During the ``make`` command, build a specific target, for instance, ``logger_test``.
 
-Test run lengths
-^^^^^^^^^^^^^^^^^
+Test runtimes
+-------------------------------------------
 
-Depending on the resources available to the machine running the selected tests, hipTensor test runtimes can be on the order of an hour or more. Here are some things you can do to reduce run-times:
+Depending on the resources available to the machine running the selected tests,
+hipTensor test runtimes can last an hour or more. Here are some things you can do to reduce test runtimes:
 
-* CTest will invoke the entire test suite. You may invoke tests individually by name.
-* Use GoogleTest filters, targeting specific test cases:
+*  CTest runs the entire test suite, but you can invoke tests individually by name.
+*  Use GoogleTest filters to target specific test cases:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    <test_exe> --gtest_filter=*name_filter*
+      <test_exe> --gtest_filter=*name_filter*
 
-* Manually adjust the test cases coverage. Using your favorite text editor, you can modify test YAML configs to affect the test parameter coverage.
-* Alternatively, use your own testing YAML config with a reduced parameter set.
-* For tests with large tensor ranks, avoid using larger lengths to reduce computational load.
+*  Manually adjust the test case coverage. Use a text editor to modify the test YAML configs to adjust the test parameter coverage.
+*  Alternatively, use your own YAML config for testing with a reduced parameter set.
+*  For tests with large tensor ranks, avoid using larger lengths to reduce the computational load.
 
 Test verbosity and file redirection
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------------
 
-Tests support logging arguments that can be used to control verbosity and output redirection.
+The tests support logging arguments to control verbosity and output redirection.
 
 .. code-block:: bash
 
-    <test_exe> -y "testing_params.yaml" -o "output.csv" --omit 1
+   <test_exe> -y "testing_params.yaml" -o "output.csv" --omit 1
 
 .. tabularcolumns::
    |C|C|C|
 
-+------------------------+-------------------------------------+--------------------------------------------------+
-|Compact                 |Verbose                              |  Description                                     |
-+========================+=====================================+==================================================+
-| -y <input_file>.yaml   |                                     | override read testing parameters from input file |
-+------------------------+-------------------------------------+--------------------------------------------------+
-| -o <output_file>.csv   |                                     | redirect gtest output to file                    |
-+------------------------+-------------------------------------+--------------------------------------------------+
-|                        |                                     | code = 1: Omit gtest SKIPPED tests               |
-|                        |                                     +--------------------------------------------------+
-|                        | --omit <code>                       | code = 2: Omit gtest FAILED tests                |
-|                        |                                     +--------------------------------------------------+
-|                        |                                     | code = 4: Omit gtest PASSED tests                |
-|                        |                                     +--------------------------------------------------+
-|                        |                                     | code = 8: Omit all gtest output                  |
-|                        |                                     +--------------------------------------------------+
-|                        |                                     | code = <N>: OR combination of 1, 2, 4            |
-+------------------------+-------------------------------------+--------------------------------------------------+
++----------------------------+-------------------------------------+--------------------------------------------------+
+|Compact                     |Verbose                              |  Description                                     |
++============================+=====================================+==================================================+
+| ``-y <input_file>.yaml``   |                                     | Override read testing parameters from input file |
++----------------------------+-------------------------------------+--------------------------------------------------+
+| ``-o <output_file>.csv``   |                                     | Redirect GoogleTest output to file               |
++----------------------------+-------------------------------------+--------------------------------------------------+
+|                            |                                     | code = 1: Omit gtest SKIPPED tests               |
+|                            |                                     +--------------------------------------------------+
+|                            | ``--omit <code>``                   | code = 2: Omit gtest FAILED tests                |
+|                            |                                     +--------------------------------------------------+
+|                            |                                     | code = 4: Omit gtest PASSED tests                |
+|                            |                                     +--------------------------------------------------+
+|                            |                                     | code = 8: Omit all gtest output                  |
+|                            |                                     +--------------------------------------------------+
+|                            |                                     | code = <N>: OR combination of 1, 2, 4            |
++----------------------------+-------------------------------------+--------------------------------------------------+

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -2,18 +2,36 @@
 # These comments will also be removed.
 root: index
 subtrees:
-  - caption:  Install
-    entries:
-    - file: install/installation
-  - caption:  Conceptual
-    entries:
-    - file: conceptual/programmers-guide
-  - caption:  API reference
-    entries:
-    - file: api-reference/api-reference    
-  - caption:  Contribution
-    entries:
-    - file: contribution/contributors-guide    
-  - caption: About
-    entries:
-    - file: license
+
+- entries:
+  - file: what-is-hiptensor.rst
+    title: What is hipTensor?
+
+- caption: Install
+  entries:
+  - file: install/installation
+    title: Installation guide
+
+- caption: Conceptual
+  entries:
+  - file: conceptual/programmers-guide
+    title: Programming guide
+
+- caption: How to
+  entries:
+  - file: contribution/contributors-guide
+    title: Contribute to hipTensor
+
+- caption: Examples
+  entries:
+  - url: https://github.com/ROCm/hipTensor/tree/develop/samples
+    title: Samples
+
+- caption: API reference
+  entries:
+  - file: api-reference/api-reference
+    title: API reference guide
+
+- caption: About
+  entries:
+   - file: license

--- a/docs/what-is-hiptensor.rst
+++ b/docs/what-is-hiptensor.rst
@@ -1,0 +1,29 @@
+.. meta::
+   :description: Introduction to the high-performance hipTensor library for tensor primitives
+   :keywords: hipTensor, ROCm, library, API, tool
+
+.. _what-is-hiptensor:
+
+********************************************************************
+What is hipTensor?
+********************************************************************
+
+hipTensor is a high-performance :doc:`HIP <hip:index>`
+library for tensor primitives. It's the AMD C++ library for accelerating tensor primitives,
+leveraging specialized GPU matrix cores on the latest AMD discrete GPUs.
+hipTensor is powered by the composable kernel (CK) library backend.
+
+The hipTensor API is designed to be portable with the NVIDIA CUDA cuTensor library, letting CUDA users easily migrate to the AMD platform.
+It offers functionality for defining tensor data objects and supports
+contraction, permutation, and reduction operations.
+Users can also select from several available logging options.
+The hipTensor library is bundled with GPU kernel instances, which are automatically selected
+and invoked to solve problems as defined by the API input parameters.
+
+Supporting host code is required for GPU device and memory management.
+The hipTensor code samples and tests provided with the library are built and launched using HIP within ROCm.
+
+.. note::
+
+   hipTensor is a work-in-progress (WIP) library. Future tensor operation support might include additional element-wise operations
+   and caching of selection instances.


### PR DESCRIPTION
* First phase of hipTensor docs refresh

* Update metadata

* Add link to samples

* Add a couple of minor corrections

* Incorporate feedback from the SW Dev review

* Fix linting and adjustment to the read me file

* Reorganize tables

* Change minimum versions

(cherry picked from commit ea759977de31aaaddcca1c8bcd9937ec297b062e)