### PR TITLE
disable warning about 'amdgpu-waves-per-eu'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,9 @@ if(HIPTENSOR_CODE_COVERAGE)
     add_link_options(-fprofile-instr-generate)
 endif()
 
+# disable warning about 'amdgpu-waves-per-eu'
+add_compile_options(-Wno-pass-failed)
+
 find_package( composable_kernel 1.0.0 REQUIRED PATHS $ENV{CK_DIR}/lib/cmake /opt/rocm /opt/rocm/ck COMPONENTS device_contraction_operations device_reduction_operations device_other_operations)
 rocm_package_add_dependencies("composable_kernel >= 1.0.0" COMPONENT tests)
 


### PR DESCRIPTION
Use the same compile option to disable warning about 'amdgpu-waves-per-eu'