### PR TITLE
fix rank5 permutation segfault

### DIFF
--- a/library/src/permutation/permutation_instance_selection.cpp
+++ b/library/src/permutation/permutation_instance_selection.cpp
@@ -4103,6 +4103,7 @@ namespace hiptensor
             {32, 128, 512, 2048, 8192, 32768, 131072, 524288},
             {32, 256, 2048, 16384, 131072},
         };
+        if(lengths.size()>=edgeList.size()) return {};
         auto&                    edges = edgeList[lengths.size()];
         std::vector<ck::index_t> point;
         point.reserve(lengths.size());
@@ -4122,18 +4123,6 @@ namespace hiptensor
     {
         if(typeIn.size() == 1)
         {
-            auto key = hipTypeToString(typeIn[0]);
-            for(auto&& index : findRepresentPointOfSubSpace(lengths))
-            {
-                key += '_';
-                key += std::to_string(index);
-            }
-            for(auto&& mode : outputMode)
-            {
-                key += '_';
-                key += std::to_string(mode);
-            }
-
             decltype(lookUpTableRank2)* lut = nullptr;
             switch(numDim)
             {
@@ -4153,6 +4142,18 @@ namespace hiptensor
             }
             if(lut)
             {
+                auto key = hipTypeToString(typeIn[0]);
+                for(auto&& index : findRepresentPointOfSubSpace(lengths))
+                {
+                    key += '_';
+                    key += std::to_string(index);
+                }
+                for(auto&& mode : outputMode)
+                {
+                    key += '_';
+                    key += std::to_string(mode);
+                }
+
                 if(auto it = lut->find(key); it != lut->cend())
                 {
                     return it->second;


### PR DESCRIPTION
In function
   static std::vector<ck::index_t> findRepresentPointOfSubSpace(std::vector<std::size_t> const& lengths)

The array "edgeList" only has 5 elements. So when rank 5 tensor is used, the size of array "lengths" is 5, the code:
      auto&    edges = edgeList[lengths.size()];
will get an "edges" that is out of boundary of array "edgeList".
Then in code:
    auto lower_edge = len <= 32 ? 32 : *std::lower_bound(edges.cbegin(), edges.cend(), len);
 it will  cause memory crash when any dimension of the rank 5 tensor greater than 32 because "edges" passed into  "std::lower_bound" is not an effective array. 

The fix is to avoid calling "findRepresentPointOfSubSpace" function when rank 5 is used and also check  "lengths" size to make sure it is less than "edgeList" size.