### PR TITLE
fix hiptensor-tests files are not getting removed after uninstallation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ include(ROCMSetupVersion)
 include(ROCMCreatePackage)
 include(ROCMInstallTargets)
 include(ROCMCheckTargetIds)
+include(ROCMClients)
 
 include(ROCMPackageConfigHelpers)
 include(ROCMInstallSymlinks)
@@ -193,13 +194,13 @@ endif()
 
 # Configure tests build
 if(HIPTENSOR_BUILD_TESTS)
-  rocm_package_setup_component(tests PARENT clients)
+  rocm_package_setup_client_component(tests)
   add_subdirectory(test)
 endif()
 
 # Configure clients build
 if(HIPTENSOR_BUILD_SAMPLES)
-  rocm_package_setup_component(samples PARENT clients)
+  rocm_package_setup_client_component(samples)
   add_subdirectory(samples)
 endif()
 


### PR DESCRIPTION
## Motivation

Fix problem that hiptensor-tests files are not getting removed after driver uninstallation

## Technical Details

Replace "rocm_package_setup_component" with "rocm_package_setup_client_component" for hiptensor-tests files in CMake.

## Test Plan

Run the regular test suite in hipTensor.

## Test Result

All good.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
