### PR TITLE
Add new option "-l" to tests to redirect logs to file

### DIFF
--- a/library/src/hiptensor_options.cpp
+++ b/library/src/hiptensor_options.cpp
@@ -31,17 +31,19 @@ namespace hiptensor
 {
     HiptensorOptions::HiptensorOptions()
         : mOstream()
+        , mLogOstream()
         , mOmitSkipped(false)
         , mOmitFailed(false)
         , mOmitPassed(false)
         , mOmitCout(false)
         , mUsingDefaultParams(true)
         , mValidate(true)
+        , mColMajorStrides(HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR)
         , mHotRuns(1)
         , mColdRuns(0)
         , mInputFilename("")
         , mOutputFilename("")
-        , mColMajorStrides(HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR)
+        , mLogFilename("")
     {
         // Override HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR with environment variable if present
         if(const char* stride_env = std::getenv("HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR"))
@@ -62,6 +64,11 @@ namespace hiptensor
     void HiptensorOptions::setOstream(std::string file)
     {
         mOstream.initializeStream(file);
+    }
+
+    void HiptensorOptions::setLogOstream(std::string file)
+    {
+        mLogOstream.initializeStream(file);
     }
 
     void HiptensorOptions::setOmits(int mask)
@@ -141,9 +148,19 @@ namespace hiptensor
         mOutputFilename = file;
     }
 
+    void HiptensorOptions::setLogStreamFilename(std::string file)
+    {
+        mLogFilename = file;
+    }
+
     HiptensorOStream& HiptensorOptions::ostream()
     {
         return mOstream;
+    }
+
+    HiptensorOStream& HiptensorOptions::logOstream()
+    {
+        return mLogOstream;
     }
 
     bool HiptensorOptions::omitSkipped()
@@ -194,6 +211,11 @@ namespace hiptensor
     std::string HiptensorOptions::outputFilename()
     {
         return mOutputFilename;
+    }
+
+    std::string HiptensorOptions::logFilename()
+    {
+        return mLogFilename;
     }
 
     bool HiptensorOptions::isColMajorStrides()

--- a/library/src/include/hiptensor_options.hpp
+++ b/library/src/include/hiptensor_options.hpp
@@ -50,6 +50,7 @@ namespace hiptensor
         ~HiptensorOptions()                  = default;
 
         void setOstream(std::string file);
+        void setLogOstream(std::string file);
         void setOmits(int mask);
         void setDefaultParams(bool val);
         void setValidation(std::string val);
@@ -57,8 +58,10 @@ namespace hiptensor
         void setColdRuns(int runs);
         void setInputYAMLFilename(std::string file);
         void setOutputStreamFilename(std::string file);
+        void setLogStreamFilename(std::string file);
 
         HiptensorOStream& ostream();
+        HiptensorOStream& logOstream();
 
         bool omitSkipped();
         bool omitFailed();
@@ -73,9 +76,10 @@ namespace hiptensor
 
         std::string inputFilename();
         std::string outputFilename();
+        std::string logFilename();
 
     protected:
-        HiptensorOStream mOstream;
+        HiptensorOStream mOstream, mLogOstream;
 
         bool mOmitSkipped, mOmitFailed, mOmitPassed, mOmitCout;
         bool mUsingDefaultParams;
@@ -84,7 +88,7 @@ namespace hiptensor
 
         int32_t mHotRuns, mColdRuns;
 
-        std::string mInputFilename, mOutputFilename;
+        std::string mInputFilename, mOutputFilename, mLogFilename;
     };
 
 } // namespace hiptensor

--- a/library/src/include/hiptensor_ostream.hpp
+++ b/library/src/include/hiptensor_ostream.hpp
@@ -28,7 +28,6 @@
 #define HIPTENSOR_IOSTREAM
 
 #include <fstream>
-#include <iostream>
 #include <utility>
 
 namespace hiptensor

--- a/library/src/logger.cpp
+++ b/library/src/logger.cpp
@@ -26,6 +26,7 @@
 
 #include "include/logger.hpp"
 
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>

--- a/test/01_contraction/contraction_test.cpp
+++ b/test/01_contraction/contraction_test.cpp
@@ -526,8 +526,6 @@ namespace hiptensor
         {
             printKernel(stream);
 
-            stream << ContractionTest::sAPILogBuff.str();
-
             if(mPrintElements)
             {
                 auto resource = getResource();
@@ -927,6 +925,7 @@ namespace hiptensor
 
             if(!loggingOptions->omitCout())
             {
+                std::cout << ContractionTest::sAPILogBuff.str();
                 reportResults(std::cout,
                               DDataType,
                               computeType,
@@ -934,6 +933,11 @@ namespace hiptensor
                               loggingOptions->omitSkipped(),
                               loggingOptions->omitFailed(),
                               loggingOptions->omitPassed());
+            }
+
+            if(loggingOptions->logOstream().isOpen())
+            {
+                loggingOptions->logOstream().fstream() << ContractionTest::sAPILogBuff.str();
             }
 
             if(loggingOptions->ostream().isOpen())

--- a/test/02_elementwise/elementwise_binary_op_test.cpp
+++ b/test/02_elementwise/elementwise_binary_op_test.cpp
@@ -26,10 +26,10 @@
 #include <hiptensor/hiptensor.hpp>
 
 #include "data_types.hpp"
+#include "elementwise/elementwise_cpu_reference.hpp"
 #include "elementwise_binary_op_test.hpp"
 #include "hiptensor_options.hpp"
 #include "logger.hpp"
-#include "elementwise/elementwise_cpu_reference.hpp"
 #include "utils.hpp"
 
 namespace hiptensor
@@ -219,8 +219,6 @@ namespace hiptensor
         if((mRunFlag || !omitSkipped) && (mValidationResult || !omitFailed)
            && (!mValidationResult || !omitPassed))
         {
-            stream << ElementwiseBinaryOpTest::sAPILogBuff.str();
-
             printKernel(stream);
 
             if(mPrintElements)
@@ -362,6 +360,8 @@ namespace hiptensor
 
             hiptensorHandle_t handle;
             CHECK_HIPTENSOR_ERROR(hiptensorCreate(&handle));
+
+            CHECK_HIPTENSOR_ERROR(hiptensorLoggerSetMask(logLevel));
 
             hiptensorTensorDescriptor_t descA = nullptr;
             CHECK_HIPTENSOR_ERROR(hiptensorCreateTensorDescriptor(
@@ -591,12 +591,18 @@ namespace hiptensor
 
         if(!loggingOptions->omitCout())
         {
+            std::cout << ElementwiseBinaryOpTest::sAPILogBuff.str();
             reportResults(std::cout,
                           dataType,
                           mHeaderPrinted,
                           loggingOptions->omitSkipped(),
                           loggingOptions->omitFailed(),
                           loggingOptions->omitPassed());
+        }
+
+        if(loggingOptions->logOstream().isOpen())
+        {
+            loggingOptions->logOstream().fstream() << ElementwiseBinaryOpTest::sAPILogBuff.str();
         }
 
         if(loggingOptions->ostream().isOpen())

--- a/test/02_elementwise/elementwise_test.cpp
+++ b/test/02_elementwise/elementwise_test.cpp
@@ -209,8 +209,6 @@ namespace hiptensor
         if((mRunFlag || !omitSkipped) && (mValidationResult || !omitFailed)
            && (!mValidationResult || !omitPassed))
         {
-            stream << PermutationTest::sAPILogBuff.str();
-
             printKernel(stream);
 
             if(mPrintElements)
@@ -315,6 +313,8 @@ namespace hiptensor
             //hiptensorStatus_t err;
             hiptensorHandle_t handle;
             CHECK_HIPTENSOR_ERROR(hiptensorCreate(&handle));
+
+            CHECK_HIPTENSOR_ERROR(hiptensorLoggerSetMask(logLevel));
 
             hiptensorTensorDescriptor_t descA = nullptr;
             CHECK_HIPTENSOR_ERROR(hiptensorCreateTensorDescriptor(
@@ -461,12 +461,18 @@ namespace hiptensor
 
         if(!loggingOptions->omitCout())
         {
+            std::cout << PermutationTest::sAPILogBuff.str();
             reportResults(std::cout,
                           abDataType,
                           mHeaderPrinted,
                           loggingOptions->omitSkipped(),
                           loggingOptions->omitFailed(),
                           loggingOptions->omitPassed());
+        }
+
+        if(loggingOptions->logOstream().isOpen())
+        {
+            loggingOptions->logOstream().fstream() << PermutationTest::sAPILogBuff.str();
         }
 
         if(loggingOptions->ostream().isOpen())

--- a/test/02_elementwise/elementwise_trinary_op_test.cpp
+++ b/test/02_elementwise/elementwise_trinary_op_test.cpp
@@ -26,10 +26,10 @@
 #include <hiptensor/hiptensor.hpp>
 
 #include "data_types.hpp"
+#include "elementwise/elementwise_cpu_reference.hpp"
 #include "elementwise_trinary_op_test.hpp"
 #include "hiptensor_options.hpp"
 #include "logger.hpp"
-#include "elementwise/elementwise_cpu_reference.hpp"
 #include "utils.hpp"
 
 namespace hiptensor
@@ -226,8 +226,6 @@ namespace hiptensor
         if((mRunFlag || !omitSkipped) && (mValidationResult || !omitFailed)
            && (!mValidationResult || !omitPassed))
         {
-            stream << ElementwiseTrinaryOpTest::sAPILogBuff.str();
-
             printKernel(stream);
 
             if(mPrintElements)
@@ -392,6 +390,8 @@ namespace hiptensor
             hiptensorStatus_t err;
             hiptensorHandle_t handle;
             CHECK_HIPTENSOR_ERROR(hiptensorCreate(&handle));
+
+            CHECK_HIPTENSOR_ERROR(hiptensorLoggerSetMask(logLevel));
 
             hiptensorTensorDescriptor_t descA = nullptr;
             CHECK_HIPTENSOR_ERROR(hiptensorCreateTensorDescriptor(
@@ -676,12 +676,18 @@ namespace hiptensor
 
         if(!loggingOptions->omitCout())
         {
+            std::cout << ElementwiseTrinaryOpTest::sAPILogBuff.str();
             reportResults(std::cout,
                           dataType,
                           mHeaderPrinted,
                           loggingOptions->omitSkipped(),
                           loggingOptions->omitFailed(),
                           loggingOptions->omitPassed());
+        }
+
+        if(loggingOptions->logOstream().isOpen())
+        {
+            loggingOptions->logOstream().fstream() << ElementwiseTrinaryOpTest::sAPILogBuff.str();
         }
 
         if(loggingOptions->ostream().isOpen())

--- a/test/03_reduction/reduction_test.cpp
+++ b/test/03_reduction/reduction_test.cpp
@@ -266,8 +266,6 @@ namespace hiptensor
         if((mRunFlag || !omitSkipped) && (mValidationResult || !omitFailed)
            && (!mValidationResult || !omitPassed))
         {
-            stream << ReductionTest::sAPILogBuff.str();
-
             printKernel(stream);
 
             if(mPrintElements)
@@ -415,6 +413,8 @@ namespace hiptensor
             hiptensorStatus_t err;
             hiptensorHandle_t handle;
             CHECK_HIPTENSOR_ERROR(hiptensorCreate(&handle));
+
+            CHECK_HIPTENSOR_ERROR(hiptensorLoggerSetMask(logLevel));
 
             hiptensorTensorDescriptor_t descA = nullptr;
             CHECK_HIPTENSOR_ERROR(hiptensorCreateTensorDescriptor(
@@ -589,12 +589,18 @@ namespace hiptensor
 
             if(!loggingOptions->omitCout())
             {
+                std::cout << ReductionTest::sAPILogBuff.str();
                 reportResults(std::cout,
                               acDataType,
                               mHeaderPrinted,
                               loggingOptions->omitSkipped(),
                               loggingOptions->omitFailed(),
                               loggingOptions->omitPassed());
+            }
+
+            if(loggingOptions->logOstream().isOpen())
+            {
+                loggingOptions->logOstream().fstream() << ReductionTest::sAPILogBuff.str();
             }
 
             if(loggingOptions->ostream().isOpen())

--- a/test/llvm/command_line_parser.cpp
+++ b/test/llvm/command_line_parser.cpp
@@ -38,9 +38,13 @@ llvm::cl::opt<std::string> hiptensorInputFilename("y",
                                                   llvm::cl::value_desc("filename"),
                                                   llvm::cl::cat(HiptensorCategory));
 llvm::cl::opt<std::string> hiptensorOutputFilename("o",
-                                                   llvm::cl::desc("Specify output filename"),
+                                                   llvm::cl::desc("Specify output CSV filename"),
                                                    llvm::cl::value_desc("filename"),
                                                    llvm::cl::cat(HiptensorCategory));
+llvm::cl::opt<std::string> hiptensorLogFilename("l",
+                                                llvm::cl::desc("Specify log filename"),
+                                                llvm::cl::value_desc("filename"),
+                                                llvm::cl::cat(HiptensorCategory));
 llvm::cl::opt<std::string>
     hiptensorValidationOption("v",
                               llvm::cl::desc("Specify whether to perform validation"),
@@ -86,6 +90,7 @@ namespace hiptensor
         // set I/O files if present
         options->setInputYAMLFilename(hiptensorInputFilename);
         options->setOutputStreamFilename(hiptensorOutputFilename);
+        options->setLogStreamFilename(hiptensorLogFilename);
 
         options->setOmits(hiptensorOmitMask);
 
@@ -104,6 +109,12 @@ namespace hiptensor
         if(!options->outputFilename().empty())
         {
             options->setOstream(options->outputFilename());
+        }
+
+        // Initialize log stream
+        if(!options->logFilename().empty())
+        {
+            options->setLogOstream(options->logFilename());
         }
     }
 }


### PR DESCRIPTION

## Motivation

When running contraction tests with `-o` option (e.g.: `./bilinear_contraction_test_m1n1k1 -o test_data.csv`), hipTensor logs are redirected altogether with the test outputs to the output CSV file, polluting and breaking its format.

This PR changes include:

- Logs are not redirected to output CSV file anymore. They are redirected to the log file provided with option "-l". If no option is provided, they are not redirected to any file.
- Logs are redirected to cout unless cout redirection is ommited with "--omit" option (there are no changes of behavior on this item).
- Enable logs according to the configured log level in the test YAML file for the GPU testsuites where the enabling command was missing (elementwise variations and reduction).


## Technical Details

In the test setup, a log callback is registered, which collects all the logs in a stream. This stream have been redirected to the output
CSV file, but now it's redirected to a new provided log file.

## Test Plan

Execute most of the tests with different flags combination to validate the redirections and suppressions happen as expected.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
