### PR TITLE
Add reference to supported data types section

### DIFF
--- a/docs/api-reference/api-reference.rst
+++ b/docs/api-reference/api-reference.rst
@@ -26,6 +26,7 @@ List of supported CDNA architectures:
 
     gfx942+ = gfx942, gfx950
 
+.. _hiptensor-supported-data-types:
 
 Supported data types
 --------------------


### PR DESCRIPTION
## Motivation

We would like to link the specific section at the main precision support page:
https://rocm.docs.amd.com/en/latest/reference/precision-support.html

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
