### PR TITLE
Small fixes and improvements

### DIFF
--- a/library/src/contraction/device/device_contraction_bilinear_complex.hpp
+++ b/library/src/contraction/device/device_contraction_bilinear_complex.hpp
@@ -687,20 +687,20 @@ namespace ck
                     auto str = std::stringstream();
 
                     // clang-format off
-        str << "DeviceContractionMultipleD_Xdl_CShuffle"
-            << "<"
-            << NumDimM << ", "
-            << NumDimN << ", "
-            << NumDimK << ", "
-            << BlockSize << ", "
-            << MPerBlock << ", "
-            << NPerBlock << ", "
-            << KPerBlock << ", "
-            << AK1 << ", "
-            << BK1 << ", "
-            << ABlockTransferSrcVectorDim << ", "
-            << BBlockTransferSrcVectorDim
-            << ">";
+                    str << "DeviceContractionMultipleD_Xdl_CShuffle"
+                        << "<"
+                        << NumDimM << ", "
+                        << NumDimN << ", "
+                        << NumDimK << ", "
+                        << BlockSize << ", "
+                        << MPerBlock << ", "
+                        << NPerBlock << ", "
+                        << KPerBlock << ", "
+                        << AK1 << ", "
+                        << BK1 << ", "
+                        << ABlockTransferSrcVectorDim << ", "
+                        << BBlockTransferSrcVectorDim
+                        << ">";
                     // clang-format on
 
                     return str.str();

--- a/library/src/contraction/hiptensor_contraction.cpp
+++ b/library/src/contraction/hiptensor_contraction.cpp
@@ -547,7 +547,7 @@ hiptensorStatus_t contractionInitPlan(const hiptensorHandle_t              handl
                  (int)currentDevice.getDeviceId(),
                  (int)realHandle->getDevice().getDeviceId(),
                  hiptensorGetErrorString(errorCode));
-        logger->logError("hiptensorInitContractionPlan", msg);
+        logger->logError("contractionInitPlan", msg);
         return HIPTENSOR_STATUS_ARCH_MISMATCH;
     }
 

--- a/library/src/contraction/hiptensor_contraction.cpp
+++ b/library/src/contraction/hiptensor_contraction.cpp
@@ -73,6 +73,16 @@ hiptensorStatus_t contractionGetWorkspaceSize(const hiptensorHandle_t           
 
     // Log API access
     char msg[512];
+    snprintf(msg,
+             sizeof(msg),
+             "handle=0x%0*llX, desc=0x%llX, planPref=0x%llX, workspacePref=0x%u, workspaceSize=0x%llX",
+             2 * (int)sizeof(void*),
+             (unsigned long long)handle,
+             (unsigned long long)desc,
+             (unsigned long long)planPref,
+             (unsigned int)workspacePref,
+             (unsigned long long)workspaceSize);
+
     logger->logAPITrace("contractionGetWorkspaceSize", msg);
 
     hiptensorStatus_t checkResult = HIPTENSOR_STATUS_SUCCESS;

--- a/library/src/hiptensor.cpp
+++ b/library/src/hiptensor.cpp
@@ -80,7 +80,7 @@ hiptensorStatus_t hiptensorCreate(hiptensorHandle_t* handle)
     }
 
     // Get the current device (handled by the Handle class)
-    auto realHandle = hiptensor::Handle::createHandle((*handle)->fields);
+    hiptensor::Handle::createHandle((*handle)->fields);
 
     return HIPTENSOR_STATUS_SUCCESS;
 }

--- a/samples/01_contraction/simple_bilinear_contraction.hpp
+++ b/samples/01_contraction/simple_bilinear_contraction.hpp
@@ -23,12 +23,8 @@
  * THE SOFTWARE.
  *
  *******************************************************************************/
-#include <algorithm>
-#include <fstream>
 #include <hiptensor/hiptensor.hpp>
 #include <hiptensor/hiptensor_types.hpp>
-#include <hiptensor/internal/hiptensor_utility.hpp>
-#include <iterator>
 #include <numeric>
 #include <unordered_map>
 

--- a/scripts/performance/BenchmarkContraction.sh
+++ b/scripts/performance/BenchmarkContraction.sh
@@ -3,7 +3,7 @@
 
 set -eux
 
-# Check if two arguments are provided
+# Check if three arguments are provided
 if [ $# -ne 3 ]; then
     echo "Usage: $0 <binary_dir> <config_dir> <output_dir>"
     exit 1

--- a/test/01_contraction/contraction_resource.hpp
+++ b/test/01_contraction/contraction_resource.hpp
@@ -61,7 +61,6 @@ namespace hiptensor
 
         // M, N, U, V, H, K
         using ProblemDims = std::vector<std::vector<std::size_t>>;
-        ;
 
         // MatrixA, MatrixB, MatrixC, MatrixD (# of elements)
         using MatrixElements = std::tuple<int64_t, int64_t, int64_t, int64_t>;


### PR DESCRIPTION
## Motivation and Technical Details

The main fix in this PR is the proper initialization of the msg var before logging it as API trace for `contractionGetWorkspaceSize`. Otherwise, it fixes comments and log texts, and clean the code by removing unused variables and unnecessary includes.

## Test Plan

Most of the changes are validated by a successful compilation.

The changes in logs were validated by running the `simple_bilinear_contraction` test with API trace log level, and manual verification of the log level.

## Test Result

Compilation and tests passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
