### PR TITLE
update version and fix a doxygen error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ if(HIPTENSOR_BUILD_SAMPLES)
 endif()
 
 # Versioning via rocm-cmake
-set ( VERSION_STRING "2.0.0" )
+set ( VERSION_STRING "2.1.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # configure a header file to pass the CMake version settings to the source

--- a/library/include/hiptensor/hiptensor.hpp
+++ b/library/include/hiptensor/hiptensor.hpp
@@ -578,4 +578,10 @@ hiptensorStatus_t hiptensorLoggerForceDisable();
 //! @retval Integer An integer representing the HIP runtime version if the operation succeeded.
 int hiptensorGetHiprtVersion();
 
+//! @brief Returns the version number of hipTensor
+//! @details Return the version with three least significant digits for patch version,
+//! the next three digits for minor version, and the most significant digits for major version.
+//! @returns The version number calculated as major * 10000 + minor * 100 + patch.
+size_t hiptensorGetVersion();
+
 #endif // HIPTENSOR_API_HPP

--- a/test/00_unit/util_test.cpp
+++ b/test/00_unit/util_test.cpp
@@ -63,7 +63,7 @@ TEST(CheckApiParamsTest, UtilTest)
 
 TEST(hiptensorGetVersionTest, UtilTest)
 {
-    EXPECT_EQ(hiptensorGetVersion(), 2000000);
+    EXPECT_EQ(hiptensorGetVersion(), 2001000);
 }
 
 TEST(logLevelToStringTest, UtilTest)


### PR DESCRIPTION
## Motivation

update version and fix a goxygen error

## Technical Details
1. Updated version - hipTensor 2.1.0 for ROCm 7.1.
2. Add hiptensorGetVersion in hiptensor.hpp to fix problem in https://github.com/ROCm/hipTensor/pull/395

## Test Plan

Normal tests.

## Test Result

All tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
