### PR TITLE
Add cmake functions to allow projects querying about architecture support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,12 +108,14 @@ else()
     set(ADDRESS_SANITIZER_ENABLED OFF)
 endif()
 
+include(cmake/Functions/hiptensorSupportedArchitectures.cmake)
 if (ADDRESS_SANITIZER_ENABLED)
     rocm_check_target_ids(DEFAULT_GPU_TARGETS
         TARGETS "gfx90a:xnack+;gfx942:xnack+;gfx950:xnack+" )
 else()
+    hiptensor_get_supported_architectures(SUPPORTED_ARCHS)
     rocm_check_target_ids(DEFAULT_GPU_TARGETS
-        TARGETS "gfx908;gfx90a;gfx942;gfx950" )
+        TARGETS ${SUPPORTED_ARCHS} )
 endif()
 
 # Check if offload compression is supported
@@ -227,6 +229,7 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
 rocm_install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/hiptensorConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/hiptensorConfigVersion.cmake"
+    "cmake/Functions/hiptensorSupportedArchitectures.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hiptensor
 )
 

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -3,9 +3,11 @@
 set(_hiptensor_supported_components hiptensor)
 
 foreach(_comp ${hiptensor_FIND_COMPONENTS})
-	if(NOT _comp IN_LIST _hiptensor_supported_components)
-		set(hiptensor_FOUND False)
-		set(hiptensor_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
-	endif()
-	include("${CMAKE_CURRENT_LIST_DIR}/${_comp}Targets.cmake")
+    if(NOT _comp IN_LIST _hiptensor_supported_components)
+        set(hiptensor_FOUND False)
+        set(hiptensor_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
+    endif()
+    include("${CMAKE_CURRENT_LIST_DIR}/${_comp}Targets.cmake")
 endforeach()
+
+include("${CMAKE_CURRENT_LIST_DIR}/hiptensorSupportedArchitectures.cmake")

--- a/cmake/Functions/hiptensorSupportedArchitectures.cmake
+++ b/cmake/Functions/hiptensorSupportedArchitectures.cmake
@@ -1,0 +1,20 @@
+set(SUPPORTED_ARCHITECTURES
+    gfx908
+    gfx90a
+    gfx942
+    gfx950
+)
+
+function(hiptensor_is_supported_architecture ARCHITECTURE_NAME RESULT_VAR)
+    list(FIND SUPPORTED_ARCHITECTURES "${ARCHITECTURE_NAME}" INDEX)
+    if (INDEX EQUAL -1)
+        set(${RESULT_VAR} FALSE PARENT_SCOPE)
+    else()
+        set(${RESULT_VAR} TRUE PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(hiptensor_get_supported_architectures RESULT_VAR)
+    string(JOIN ";" SUPPORTED_ARCHITECTURES_STRING ${SUPPORTED_ARCHITECTURES})
+    set(${RESULT_VAR} "${SUPPORTED_ARCHITECTURES_STRING}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
## Motivation

Depending projects can use these functions to check if an architecture is supported or not, and take different paths accordingly.

## Technical Details

New cmake function created, exported, and included to make it visible for projects including hipTensor with `find_package(hiptensor)` in their CMakes.

## Test Plan

1. Build and install hipTensor to verify the newly added files are properly installed.
2. Change rocm-examples to use one of the newly provided functions and make sure it compiles properly.

## Test Result

Files were installed correctly and both hipTensor and rocm-examples are building correctly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
