### PR TITLE
Convert include guards from #ifndef/#define/#endif to #pragma once

### DIFF
--- a/library/src/contraction/contraction_cpu_reference.hpp
+++ b/library/src/contraction/contraction_cpu_reference.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_CPU_REFERENCE_HPP
-#define HIPTENSOR_CONTRACTION_CPU_REFERENCE_HPP
+#pragma once
 
 #include <hip/library_types.h>
 #include <vector>
@@ -57,4 +56,3 @@ hiptensorStatus_t hiptensorContractionReference(const hiptensorPlan_t       plan
                                                 hiptensorDataType_t         typeD,
                                                 void*                       workspace);
 
-#endif // HIPTENSOR_CONTRACTION_CPU_REFERENCE_HPP

--- a/library/src/contraction/contraction_cpu_reference_impl.hpp
+++ b/library/src/contraction/contraction_cpu_reference_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_CPU_REFERENCE_IMPL_HPP
-#define HIPTENSOR_CONTRACTION_CPU_REFERENCE_IMPL_HPP
+#pragma once
 
 // Std includes
 #include <array>
@@ -634,4 +633,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_CPU_REFERENCE_IMPL_HPP

--- a/library/src/contraction/contraction_cpu_reference_instances.hpp
+++ b/library/src/contraction/contraction_cpu_reference_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_CPU_REFERENCE_INSTANCES_HPP
-#define HIPTENSOR_CONTRACTION_CPU_REFERENCE_INSTANCES_HPP
+#pragma once
 
 #include <memory>
 
@@ -55,5 +54,3 @@ namespace hiptensor
     };
 
 } // namespace hiptensor
-
-#endif // HIPTENSOR_CONTRACTION_SOLUTION_INSTANCES_HPP

--- a/library/src/contraction/contraction_meta_traits.hpp
+++ b/library/src/contraction/contraction_meta_traits.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_META_TRAITS_HPP
-#define HIPTENSOR_CONTRACTION_META_TRAITS_HPP
+#pragma once
 
 // CK includes
 #include <contraction_bilinear.hpp>
@@ -148,4 +147,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_META_TRAITS_HPP

--- a/library/src/contraction/contraction_pack_util.hpp
+++ b/library/src/contraction/contraction_pack_util.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_PACK_UTIL_HPP
-#define HIPTENSOR_CONTRACTION_PACK_UTIL_HPP
+#pragma once
 
 #include "data_types.hpp"
 #include "util.hpp"
@@ -137,4 +136,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_PACK_UTIL_HPP

--- a/library/src/contraction/contraction_selection.hpp
+++ b/library/src/contraction/contraction_selection.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_HEURISTICS_HPP
-#define HIPTENSOR_CONTRACTION_HEURISTICS_HPP
+#pragma once
 
 #include "contraction_solution.hpp"
 #include <vector>
@@ -110,4 +109,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_HEURISTICS_HPP

--- a/library/src/contraction/contraction_solution.hpp
+++ b/library/src/contraction/contraction_solution.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_SOLUTION_HPP
-#define HIPTENSOR_CONTRACTION_SOLUTION_HPP
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -167,4 +166,3 @@ namespace hiptensor
 
 #include "contraction_solution_impl.hpp"
 
-#endif // HIPTENSOR_CONTRACTION_SOLUTION_HPP

--- a/library/src/contraction/contraction_solution_impl.hpp
+++ b/library/src/contraction/contraction_solution_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_SOLUTION_IMPL_HPP
-#define HIPTENSOR_CONTRACTION_SOLUTION_IMPL_HPP
+#pragma once
 
 #include <algorithm>
 #include <numeric>
@@ -380,4 +379,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_SOLUTION_IMPL_HPP

--- a/library/src/contraction/contraction_solution_instances.hpp
+++ b/library/src/contraction/contraction_solution_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_SOLUTION_INSTANCES_HPP
-#define HIPTENSOR_CONTRACTION_SOLUTION_INSTANCES_HPP
+#pragma once
 
 #include <memory>
 
@@ -55,4 +54,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_SOLUTION_INSTANCES_HPP

--- a/library/src/contraction/contraction_solution_params.hpp
+++ b/library/src/contraction/contraction_solution_params.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_SOLUTION_PARAMS_HPP
-#define HIPTENSOR_CONTRACTION_SOLUTION_PARAMS_HPP
+#pragma once
 
 #include <hiptensor/hiptensor_types.h>
 
@@ -65,4 +64,3 @@ namespace hiptensor
 
 #include "contraction_solution_params_impl.hpp"
 
-#endif // HIPTENSOR_CONTRACTION_SOLUTION_PARAMS_HPP

--- a/library/src/contraction/contraction_solution_params_impl.hpp
+++ b/library/src/contraction/contraction_solution_params_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_SOLUTION_PARAMS_IMPL_HPP
-#define HIPTENSOR_CONTRACTION_SOLUTION_PARAMS_IMPL_HPP
+#pragma once
 
 #include "contraction_meta_traits.hpp"
 #include "contraction_solution_params.hpp"
@@ -126,4 +125,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_SOLUTION_PARAMS_IMPL_HPP

--- a/library/src/contraction/contraction_solution_registry.hpp
+++ b/library/src/contraction/contraction_solution_registry.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_SOLUTION_REGISTRY_HPP
-#define HIPTENSOR_CONTRACTION_SOLUTION_REGISTRY_HPP
+#pragma once
 
 #include <memory>
 #include <unordered_map>
@@ -160,4 +159,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_SOLUTION_REGISTRY_HPP

--- a/library/src/contraction/contraction_types.hpp
+++ b/library/src/contraction/contraction_types.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_TYPES_HPP
-#define HIPTENSOR_CONTRACTION_TYPES_HPP
+#pragma once
 
 #include <ostream>
 
@@ -69,4 +68,3 @@ namespace std
 
 #include "contraction_types_impl.hpp"
 
-#endif // HIPTENSOR_CONTRACTION_TYPES_HPP

--- a/library/src/contraction/contraction_types_impl.hpp
+++ b/library/src/contraction/contraction_types_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_TYPES_IMPL_HPP
-#define HIPTENSOR_CONTRACTION_TYPES_IMPL_HPP
+#pragma once
 
 // CK includes
 #include <contraction_bilinear.hpp>
@@ -72,4 +71,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_TYPES_IMPL_HPP

--- a/library/src/contraction/device/common.hpp
+++ b/library/src/contraction/device/common.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef CONTRACTION_DEVICE_COMMON_HPP
-#define CONTRACTION_DEVICE_COMMON_HPP
+#pragma once
 
 // Stdlib includes
 #include <cstdlib>
@@ -41,4 +40,3 @@
 
 #include "device_element_wise_operation_complex.hpp"
 
-#endif // CONTRACTION_DEVICE_COMMON_HPP

--- a/library/src/contraction/device/device_contraction_bilinear_complex.hpp
+++ b/library/src/contraction/device/device_contraction_bilinear_complex.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_BILINEAR_COMPLEX_HPP
-#define HIPTENSOR_CONTRACTION_BILINEAR_COMPLEX_HPP
+#pragma once
 
 #include "../contraction_pack_util.hpp"
 #include "common.hpp"
@@ -711,4 +710,3 @@ namespace ck
     } // namespace tensor_operation
 } // namespace ck
 
-#endif // HIPTENSOR_CONTRACTION_BILINEAR_COMPLEX_HPP

--- a/library/src/contraction/device/device_contraction_scale_complex.hpp
+++ b/library/src/contraction/device/device_contraction_scale_complex.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_SCALE_COMPLEX_HPP
-#define HIPTENSOR_CONTRACTION_SCALE_COMPLEX_HPP
+#pragma once
 
 #include "../contraction_pack_util.hpp"
 #include "common.hpp"
@@ -701,4 +700,3 @@ namespace ck
     } // namespace tensor_operation
 } // namespace ck
 
-#endif // HIPTENSOR_CONTRACTION_SCALE_COMPLEX_HPP

--- a/library/src/contraction/device/device_element_wise_operation_complex.hpp
+++ b/library/src/contraction/device/device_element_wise_operation_complex.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_ELEMENT_WISE_OPERATION_COMPLEX_HPP
-#define HIPTENSOR_ELEMENT_WISE_OPERATION_COMPLEX_HPP
+#pragma once
 
 #include <binary_element_wise_operation.hpp>
 #include <hip/hip_complex.h>
@@ -110,4 +109,3 @@ namespace ck
     } // namespace tensor_operation
 } // namespace ck
 
-#endif // HIPTENSOR_ELEMENT_WISE_OPERATION_COMPLEX_HPP

--- a/library/src/contraction/device/hiptensor_contraction_bilinear_instances.hpp
+++ b/library/src/contraction/device/hiptensor_contraction_bilinear_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef CONTRACTION_BILINEAR_HPP
-#define CONTRACTION_BILINEAR_HPP
+#pragma once
 
 #include "common.hpp"
 
@@ -242,4 +241,3 @@ namespace ck
     } // namespace tensor_operation
 } // namespace ck
 
-#endif // CONTRACTION_BILINEAR_HPP

--- a/library/src/contraction/device/hiptensor_contraction_scale_instances.hpp
+++ b/library/src/contraction/device/hiptensor_contraction_scale_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef CONTRACTION_SCALE_HPP
-#define CONTRACTION_SCALE_HPP
+#pragma once
 
 #include "common.hpp"
 
@@ -238,4 +237,3 @@ namespace ck
     } // namespace tensor_operation
 } // namespace ck
 
-#endif // CONTRACTION_SCALE_HPP

--- a/library/src/elementwise/device/hiptensor_ck_types.hpp
+++ b/library/src/elementwise/device/hiptensor_ck_types.hpp
@@ -25,8 +25,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CK_TYPES_HPP
-#define HIPTENSOR_CK_TYPES_HPP
+#pragma once
 
 #include <ck/ck.hpp>
 #include <ck/tensor_operation/gpu/device/device_elementwise.hpp>
@@ -57,4 +56,3 @@ namespace hiptensor
                                                                          CkUnaryCombinedOp>;
 }
 
-#endif // HIPTENSOR_CK_TYPES_HPP

--- a/library/src/elementwise/device/hiptensor_elementwise_scale_instances.hpp
+++ b/library/src/elementwise/device/hiptensor_elementwise_scale_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_SCALE_INSTANCES_HPP
-#define HIPTENSOR_PERMUTATION_SCALE_INSTANCES_HPP
+#pragma once
 
 // Stdlib includes
 #include <cstdlib>
@@ -350,4 +349,3 @@ namespace ck
     } // namespace tensor_operation
 } // namespace ck
 
-#endif // HIPTENSOR_PERMUTATION_SCALE_INSTANCES_HPP

--- a/library/src/elementwise/device/instance_params.hpp
+++ b/library/src/elementwise/device/instance_params.hpp
@@ -23,8 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#ifndef INSTANCE_PARAMS_HPP
-#define INSTANCE_PARAMS_HPP
+#pragma once
 
 #include "../elementwise_types.hpp"
 #include "data_types.hpp"
@@ -196,4 +195,3 @@ namespace std
         }
     };
 }
-#endif //  INSTANCE_PARAMS_HPP

--- a/library/src/elementwise/elementwise_cpu_reference.hpp
+++ b/library/src/elementwise/elementwise_cpu_reference.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_CPU_REFERENCE_HPP
-#define HIPTENSOR_PERMUTATION_CPU_REFERENCE_HPP
+#pragma once
 
 #include <hip/library_types.h>
 #include <vector>
@@ -81,4 +80,3 @@ hiptensorStatus_t hiptensorElementwiseTrinaryOpReference(const void*            
                                                          hiptensorOperator_t               opABC,
                                                          hiptensorDataType_t typeScalar,
                                                          hipStream_t         stream);
-#endif // HIPTENSOR_PERMUTATION_CPU_REFERENCE_HPP

--- a/library/src/elementwise/elementwise_cpu_reference_impl.hpp
+++ b/library/src/elementwise/elementwise_cpu_reference_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_CPU_REFERENCE_IMPL_HPP
-#define HIPTENSOR_PERMUTATION_CPU_REFERENCE_IMPL_HPP
+#pragma once
 
 // Std includes
 #include <array>
@@ -293,4 +292,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PERMUTATION_CPU_REFERENCE_IMPL_HPP

--- a/library/src/elementwise/elementwise_cpu_reference_instances.hpp
+++ b/library/src/elementwise/elementwise_cpu_reference_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_CPU_REFERENCE_INSTANCES_HPP
-#define HIPTENSOR_PERMUTATION_CPU_REFERENCE_INSTANCES_HPP
+#pragma once
 
 #include <memory>
 
@@ -60,5 +59,3 @@ namespace hiptensor
     };
 
 } // namespace hiptensor
-
-#endif // HIPTENSOR_PERMUTATION_SOLUTION_INSTANCES_HPP

--- a/library/src/elementwise/elementwise_instance_selection.hpp
+++ b/library/src/elementwise/elementwise_instance_selection.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef PERMUTATION_INSTANCE_SELECTION_HPP
-#define PERMUTATION_INSTANCE_SELECTION_HPP
+#pragma once
 
 #include "data_types.hpp"
 #include "elementwise_types.hpp"
@@ -39,4 +38,3 @@ namespace hiptensor
                                              ck::index_t                             numDim);
 } // namespace hiptensor
 
-#endif // PERMUTATION_INSTANCE_SELECTION_HPP

--- a/library/src/elementwise/elementwise_meta_traits.hpp
+++ b/library/src/elementwise/elementwise_meta_traits.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_META_TRAITS_HPP
-#define HIPTENSOR_PERMUTATION_META_TRAITS_HPP
+#pragma once
 
 // CK includes
 #include <combined_element_wise_operation.hpp>
@@ -132,4 +131,3 @@ namespace hiptensor
     };
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PERMUTATION_META_TRAITS_HPP

--- a/library/src/elementwise/elementwise_solution.hpp
+++ b/library/src/elementwise/elementwise_solution.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_SOLUTION_HPP
-#define HIPTENSOR_PERMUTATION_SOLUTION_HPP
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -104,4 +103,3 @@ namespace hiptensor
 
 #include "elementwise_solution_impl.hpp"
 
-#endif // HIPTENSOR_PERMUTATION_SOLUTION_HPP

--- a/library/src/elementwise/elementwise_solution_impl.hpp
+++ b/library/src/elementwise/elementwise_solution_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_SOLUTION_IMPL_HPP
-#define HIPTENSOR_PERMUTATION_SOLUTION_IMPL_HPP
+#pragma once
 
 #include <map>
 #include <numeric>
@@ -248,4 +247,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PERMUTATION_SOLUTION_IMPL_HPP

--- a/library/src/elementwise/elementwise_solution_instances.hpp
+++ b/library/src/elementwise/elementwise_solution_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_SOLUTION_INSTANCES_HPP
-#define HIPTENSOR_PERMUTATION_SOLUTION_INSTANCES_HPP
+#pragma once
 
 #include <memory>
 
@@ -105,4 +104,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PERMUTATION_SOLUTION_INSTANCES_HPP

--- a/library/src/elementwise/elementwise_solution_registry.hpp
+++ b/library/src/elementwise/elementwise_solution_registry.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_SOLUTION_REGISTRY_HPP
-#define HIPTENSOR_PERMUTATION_SOLUTION_REGISTRY_HPP
+#pragma once
 
 #include <memory>
 #include <unordered_map>
@@ -72,4 +71,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PERMUTATION_SOLUTION_REGISTRY_HPP

--- a/library/src/elementwise/elementwise_types.hpp
+++ b/library/src/elementwise/elementwise_types.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_TYPES_HPP
-#define HIPTENSOR_PERMUTATION_TYPES_HPP
+#pragma once
 
 #include <ck/ck.hpp>
 #include <ck/utility/sequence.hpp>
@@ -93,4 +92,3 @@ namespace std
 
 } // namespace std
 
-#endif // HIPTENSOR_PERMUTATION_TYPES_HPP

--- a/library/src/include/data_types.hpp
+++ b/library/src/include/data_types.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_LIBRARY_DATA_TYPES_HPP
-#define HIPTENSOR_LIBRARY_DATA_TYPES_HPP
+#pragma once
 
 // clang-format off
 // Include order needs to be preserved
@@ -224,4 +223,3 @@ namespace std
 
 #include "data_types_impl.hpp"
 
-#endif // HIPTENSOR_LIBRARY_DATA_TYPES_HPP

--- a/library/src/include/data_types_impl.hpp
+++ b/library/src/include/data_types_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_LIBRARY_DATA_TYPES_IMPL_HPP
-#define HIPTENSOR_LIBRARY_DATA_TYPES_IMPL_HPP
+#pragma once
 
 #include "data_types.hpp"
 
@@ -222,4 +221,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_LIBRARY_DATA_TYPES_IMPL_HPP

--- a/library/src/include/handle.hpp
+++ b/library/src/include/handle.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_HANDLE_HPP
-#define HIPTENSOR_HANDLE_HPP
+#pragma once
 
 #include <new>
 
@@ -53,4 +52,3 @@ namespace hiptensor
     };
 } // namespace hiptensor
 
-#endif // HIPTENSOR_HANDLE_HPP

--- a/library/src/include/hash.hpp
+++ b/library/src/include/hash.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_HASH_HPP
-#define HIPTENSOR_HASH_HPP
+#pragma once
 
 #include <functional>
 #include <vector>
@@ -82,4 +81,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_HASH_HPP

--- a/library/src/include/hip_device.hpp
+++ b/library/src/include/hip_device.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_HIP_DEVICE_HPP
-#define HIPTENSOR_HIP_DEVICE_HPP
+#pragma once
 
 #include <hip/hip_runtime_api.h>
 
@@ -72,4 +71,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_HIP_DEVICE_HPP

--- a/library/src/include/hiptensor_element_wise_operation.hpp
+++ b/library/src/include/hiptensor_element_wise_operation.hpp
@@ -24,8 +24,8 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_UNARY_ELEMENT_WISE_OPERATION
-#define HIPTENSOR_UNARY_ELEMENT_WISE_OPERATION
+#pragma once
+
 #include <cassert>
 
 #include <ck/utility/data_type.hpp>
@@ -382,4 +382,3 @@ namespace ck
         } // namespace element_wise
     } // namespace tensor_operation
 } // namespace ck
-#endif // HIPTENSOR_UNARY_ELEMENT_WISE_OPERATION

--- a/library/src/include/hiptensor_options.hpp
+++ b/library/src/include/hiptensor_options.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_OPTIONS
-#define HIPTENSOR_OPTIONS
+#pragma once
 
 #include <stdlib.h>
 
@@ -93,4 +92,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_OPTIONS

--- a/library/src/include/hiptensor_ostream.hpp
+++ b/library/src/include/hiptensor_ostream.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_IOSTREAM
-#define HIPTENSOR_IOSTREAM
+#pragma once
 
 #include <fstream>
 #include <utility>
@@ -77,4 +76,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_IOSTREAM

--- a/library/src/include/logger.hpp
+++ b/library/src/include/logger.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_LOGGER_HPP
-#define HIPTENSOR_LOGGER_HPP
+#pragma once
 
 #include "singleton.hpp"
 
@@ -101,4 +100,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_LOGGER_HPP

--- a/library/src/include/meta_traits.hpp
+++ b/library/src/include/meta_traits.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_META_TRAITS_HPP
-#define HIPTENSOR_META_TRAITS_HPP
+#pragma once
 
 namespace hiptensor
 {
@@ -37,4 +36,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_META_TRAITS_HPP

--- a/library/src/include/performance.hpp
+++ b/library/src/include/performance.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERFORMANCE_HPP
-#define HIPTENSOR_PERFORMANCE_HPP
+#pragma once
 
 #include <ostream>
 #include <string>
@@ -54,4 +53,3 @@ namespace std
     ostream& operator<<(std::ostream& os, hiptensor::PerfMetrics const& metrics);
 } // namespace std
 
-#endif // HIPTENSOR_PERFORMANCE_HPP

--- a/library/src/include/plan_cache.hpp
+++ b/library/src/include/plan_cache.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PLAN_CACHE_HPP
-#define HIPTENSOR_PLAN_CACHE_HPP
+#pragma once
 
 #include <chrono>
 #include <fstream>
@@ -264,4 +263,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PLAN_CACHE_HPP

--- a/library/src/include/plancache_autotune.hpp
+++ b/library/src/include/plancache_autotune.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PLAN_CACHE_AUTOTUNE_HPP
-#define HIPTENSOR_PLAN_CACHE_AUTOTUNE_HPP
+#pragma once
 
 #include <unordered_map>
 #include <vector>
@@ -168,4 +167,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PLAN_CACHE_AUTOTUNE_HPP

--- a/library/src/include/singleton.hpp
+++ b/library/src/include/singleton.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_SINGLETON_HPP
-#define HIPTENSOR_SINGLETON_HPP
+#pragma once
 
 #include <memory>
 
@@ -45,4 +44,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_SINGLETON_HPP

--- a/library/src/reduction/device/hiptensor_device_reduce.hpp
+++ b/library/src/reduction/device/hiptensor_device_reduce.hpp
@@ -23,8 +23,7 @@
  * THE SOFTWARE.
  *
  *******************************************************************************/
-#ifndef REDUCTION_DEVICE_HIPTENSOR_DEVICE_REDUCE
-#define REDUCTION_DEVICE_HIPTENSOR_DEVICE_REDUCE
+#pragma once
 
 #include <array>
 #include <memory>
@@ -102,4 +101,3 @@ namespace ck
         } // namespace device
     } // namespace tensor_operation
 } // namespace ck
-#endif // REDUCTION_DEVICE_HIPTENSOR_DEVICE_REDUCE

--- a/library/src/reduction/device/hiptensor_device_reduce_multiblock.hpp
+++ b/library/src/reduction/device/hiptensor_device_reduce_multiblock.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef REDUCTION_DEVICE_HIPTENSOR_DEVICE_REDUCE_MULTIBLOCK
-#define REDUCTION_DEVICE_HIPTENSOR_DEVICE_REDUCE_MULTIBLOCK
+#pragma once
 
 #include <array>
 #include <iostream>
@@ -601,4 +600,3 @@ namespace ck
         } // namespace device
     } // namespace tensor_operation
 } // namespace ck
-#endif // REDUCTION_DEVICE_HIPTENSOR_DEVICE_REDUCE_MULTIBLOCK

--- a/library/src/reduction/device/hiptensor_dynamic_buffer.hpp
+++ b/library/src/reduction/device/hiptensor_dynamic_buffer.hpp
@@ -23,8 +23,7 @@
  * THE SOFTWARE.
  *
  *******************************************************************************/
-#ifndef REDUCTION_DEVICE_HIPTENSOR_DYNAMIC_BUFFER
-#define REDUCTION_DEVICE_HIPTENSOR_DYNAMIC_BUFFER
+#pragma once
 
 #include "c_style_pointer_cast.hpp"
 #include "ck/ck.hpp"
@@ -527,4 +526,3 @@ namespace ck
     }
 
 } // namespace ck
-#endif // REDUCTION_DEVICE_HIPTENSOR_DYNAMIC_BUFFER

--- a/library/src/reduction/device/hiptensor_gridwise_2d_reduction_multiblock.hpp
+++ b/library/src/reduction/device/hiptensor_gridwise_2d_reduction_multiblock.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef REDUCTION_DEVICE_HIPTENSOR_GRIDWISE_2D_REDUCTION_MULTIBLOCK
-#define REDUCTION_DEVICE_HIPTENSOR_GRIDWISE_2D_REDUCTION_MULTIBLOCK
+#pragma once
 
 #include "ck/tensor_operation/gpu/block/reduction_functions_blockwise.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
@@ -346,4 +345,3 @@ namespace ck
     };
 
 } // namespace ck
-#endif // REDUCTION_DEVICE_HIPTENSOR_GRIDWISE_2D_REDUCTION_MULTIBLOCK

--- a/library/src/reduction/device/hiptensor_reference_reduce.hpp
+++ b/library/src/reduction/device/hiptensor_reference_reduce.hpp
@@ -23,8 +23,7 @@
  * THE SOFTWARE.
  *
  *******************************************************************************/
-#ifndef REDUCTION_DEVICE_HIPTENSOR_REFERENCE_REDUCE
-#define REDUCTION_DEVICE_HIPTENSOR_REFERENCE_REDUCE
+#pragma once
 
 #include <algorithm>
 #include <array>
@@ -496,4 +495,3 @@ namespace ck
         } // namespace host
     } // namespace tensor_operation
 } // namespace ck
-#endif // REDUCTION_DEVICE_HIPTENSOR_REFERENCE_REDUCE

--- a/library/src/reduction/reduction_cpu_reference.hpp
+++ b/library/src/reduction/reduction_cpu_reference.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_CPU_REFERENCE_HPP
-#define HIPTENSOR_REDUCTION_CPU_REFERENCE_HPP
+#pragma once
 
 #include <hip/library_types.h>
 #include <vector>
@@ -48,4 +47,3 @@ hiptensorStatus_t hiptensorReductionReference(const void*                       
                                               hiptensorOperator_t               opReduce,
                                               hiptensorComputeDescriptor_t      typeCompute,
                                               hipStream_t                       stream);
-#endif // HIPTENSOR_REDUCTION_CPU_REFERENCE_HPP

--- a/library/src/reduction/reduction_cpu_reference_impl.hpp
+++ b/library/src/reduction/reduction_cpu_reference_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_CPU_REFERENCE_IMPL_HPP
-#define HIPTENSOR_REDUCTION_CPU_REFERENCE_IMPL_HPP
+#pragma once
 
 // Std includes
 #include <array>
@@ -143,4 +142,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_CPU_REFERENCE_IMPL_HPP

--- a/library/src/reduction/reduction_cpu_reference_instances.hpp
+++ b/library/src/reduction/reduction_cpu_reference_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_CPU_REFERENCE_INSTANCES_HPP
-#define HIPTENSOR_REDUCTION_CPU_REFERENCE_INSTANCES_HPP
+#pragma once
 
 #include <memory>
 
@@ -59,5 +58,3 @@ namespace hiptensor
     };
 
 } // namespace hiptensor
-
-#endif // HIPTENSOR_REDUCTION_SOLUTION_INSTANCES_HPP

--- a/library/src/reduction/reduction_meta_traits.hpp
+++ b/library/src/reduction/reduction_meta_traits.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_META_TRAITS_HPP
-#define HIPTENSOR_REDUCTION_META_TRAITS_HPP
+#pragma once
 
 #include <hiptensor/internal/types.hpp>
 
@@ -97,4 +96,3 @@ namespace hiptensor
     };
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_META_TRAITS_HPP

--- a/library/src/reduction/reduction_solution.hpp
+++ b/library/src/reduction/reduction_solution.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_SOLUTION_HPP
-#define HIPTENSOR_REDUCTION_SOLUTION_HPP
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -136,4 +135,3 @@ namespace hiptensor
 
 #include "reduction_solution_impl.hpp"
 
-#endif // HIPTENSOR_REDUCTION_SOLUTION_HPP

--- a/library/src/reduction/reduction_solution_impl.hpp
+++ b/library/src/reduction/reduction_solution_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_SOLUTION_IMPL_HPP
-#define HIPTENSOR_REDUCTION_SOLUTION_IMPL_HPP
+#pragma once
 
 #include <map>
 #include <numeric>
@@ -282,4 +281,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_SOLUTION_IMPL_HPP

--- a/library/src/reduction/reduction_solution_instances.hpp
+++ b/library/src/reduction/reduction_solution_instances.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_SOLUTION_INSTANCES_HPP
-#define HIPTENSOR_REDUCTION_SOLUTION_INSTANCES_HPP
+#pragma once
 
 #include <memory>
 
@@ -177,4 +176,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_SOLUTION_INSTANCES_HPP

--- a/library/src/reduction/reduction_solution_params.hpp
+++ b/library/src/reduction/reduction_solution_params.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_SOLUTION_PARAMS_HPP
-#define HIPTENSOR_REDUCTION_SOLUTION_PARAMS_HPP
+#pragma once
 
 #include <memory>
 #include <unordered_map>
@@ -62,4 +61,3 @@ namespace hiptensor
 
 #include "reduction_solution_params_impl.hpp"
 
-#endif // HIPTENSOR_REDUCTION_SOLUTION_PARAMS_HPP

--- a/library/src/reduction/reduction_solution_params_impl.hpp
+++ b/library/src/reduction/reduction_solution_params_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_SOLUTION_PARAMS_IMPL_HPP
-#define HIPTENSOR_REDUCTION_SOLUTION_PARAMS_IMPL_HPP
+#pragma once
 
 #include "data_types.hpp"
 #include "hash.hpp"
@@ -126,4 +125,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_SOLUTION_PARAMS_IMPL_HPP

--- a/library/src/reduction/reduction_solution_registry.hpp
+++ b/library/src/reduction/reduction_solution_registry.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_SOLUTION_REGISTRY_HPP
-#define HIPTENSOR_REDUCTION_SOLUTION_REGISTRY_HPP
+#pragma once
 
 #include <memory>
 #include <unordered_map>
@@ -132,4 +131,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_SOLUTION_REGISTRY_HPP

--- a/library/src/reduction/reduction_types.hpp
+++ b/library/src/reduction/reduction_types.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_TYPES_HPP
-#define HIPTENSOR_REDUCTION_TYPES_HPP
+#pragma once
 
 #include <ck/tensor_operation/gpu/device/reduction_operator_mapping.hpp>
 #include <ck/utility/reduction_enums.hpp>
@@ -62,4 +61,3 @@ namespace hiptensor
         static constexpr auto value = ck::ReduceTensorOp::MAX;
     };
 } // namespace hiptensor
-#endif // HIPTENSOR_REDUCTION_TYPES_HPP

--- a/samples/01_contraction/simple_bilinear_contraction.hpp
+++ b/samples/01_contraction/simple_bilinear_contraction.hpp
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  *
  *******************************************************************************/
+#pragma once
+
 #include <hiptensor/hiptensor.h>
 #include <hiptensor/hiptensor_types.h>
 #include <numeric>

--- a/samples/01_contraction/simple_scale_contraction.hpp
+++ b/samples/01_contraction/simple_scale_contraction.hpp
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  *
  *******************************************************************************/
+#pragma once
+
 #include <algorithm>
 #include <fstream>
 #include <hiptensor/hiptensor.h>

--- a/test/01_contraction/contraction_resource.hpp
+++ b/test/01_contraction/contraction_resource.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_RESOURCE_HPP
-#define HIPTENSOR_CONTRACTION_RESOURCE_HPP
+#pragma once
 
 #include <memory>
 #include <tuple>
@@ -117,4 +116,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_RESOURCE_HPP

--- a/test/01_contraction/contraction_test.hpp
+++ b/test/01_contraction/contraction_test.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_TEST_HPP
-#define HIPTENSOR_CONTRACTION_TEST_HPP
+#pragma once
 
 #include <sstream>
 
@@ -148,4 +147,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_TEST_HPP

--- a/test/01_contraction/contraction_test_helpers.hpp
+++ b/test/01_contraction/contraction_test_helpers.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_TEST_HELPERS_HPP
-#define HIPTENSOR_CONTRACTION_TEST_HELPERS_HPP
+#pragma once
 
 #include <gtest/gtest.h>
 
@@ -197,4 +196,3 @@ auto inline load_sequence_config_params()
     return ::testing::ValuesIn(paramsSequence);
 }
 
-#endif // HIPTENSOR_CONTRACTION_TEST_HELPERS_HPP

--- a/test/01_contraction/contraction_test_params.hpp
+++ b/test/01_contraction/contraction_test_params.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_CONTRACTION_TEST_PARAMS_HPP
-#define HIPTENSOR_CONTRACTION_TEST_PARAMS_HPP
+#pragma once
 
 #include <tuple>
 #include <vector>
@@ -149,4 +148,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_CONTRACTION_TEST_PARAMS_HPP

--- a/test/02_elementwise/elementwise_binary_op_test.hpp
+++ b/test/02_elementwise/elementwise_binary_op_test.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef ELEMENTWISE_BINARY_OP_TEST_HPP
-#define ELEMENTWISE_BINARY_OP_TEST_HPP
+#pragma once
 
 #include <sstream>
 
@@ -110,4 +109,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // ELEMENTWISE_BINARY_OP_TEST_HPP

--- a/test/02_elementwise/elementwise_binary_op_test_helpers.hpp
+++ b/test/02_elementwise/elementwise_binary_op_test_helpers.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef ELEMENTWISE_BINARY_OP_TEST_HELPERS_HPP
-#define ELEMENTWISE_BINARY_OP_TEST_HELPERS_HPP
+#pragma once
 
 #include <gtest/gtest.h>
 
@@ -132,4 +131,3 @@ auto inline load_config_helper()
                               ::testing::ValuesIn(testParams.operators()));
 }
 
-#endif // ELEMENTWISE_BINARY_OP_TEST_HELPERS_HPP

--- a/test/02_elementwise/elementwise_resource.hpp
+++ b/test/02_elementwise/elementwise_resource.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_RESOURCE_HPP
-#define HIPTENSOR_PERMUTATION_RESOURCE_HPP
+#pragma once
 
 #include <memory>
 #include <tuple>
@@ -125,4 +124,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PERMUTATION_RESOURCE_HPP

--- a/test/02_elementwise/elementwise_test.hpp
+++ b/test/02_elementwise/elementwise_test.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_TEST_HPP
-#define HIPTENSOR_PERMUTATION_TEST_HPP
+#pragma once
 
 #include <sstream>
 
@@ -108,4 +107,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PERMUTATION_TEST_HPP

--- a/test/02_elementwise/elementwise_test_helpers.hpp
+++ b/test/02_elementwise/elementwise_test_helpers.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_TEST_HELPERS_HPP
-#define HIPTENSOR_PERMUTATION_TEST_HELPERS_HPP
+#pragma once
 
 #include <gtest/gtest.h>
 
@@ -127,4 +126,3 @@ auto inline load_config_helper()
                               ::testing::ValuesIn(testParams.operators()));
 }
 
-#endif // HIPTENSOR_PERMUTATION_TEST_HELPERS_HPP

--- a/test/02_elementwise/elementwise_test_params.hpp
+++ b/test/02_elementwise/elementwise_test_params.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_PERMUTATION_TEST_PARAMS_HPP
-#define HIPTENSOR_PERMUTATION_TEST_PARAMS_HPP
+#pragma once
 
 #include <tuple>
 #include <vector>
@@ -131,4 +130,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_PERMUTATION_TEST_PARAMS_HPP

--- a/test/02_elementwise/elementwise_trinary_op_test.hpp
+++ b/test/02_elementwise/elementwise_trinary_op_test.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef ELEMENTWISE_TRINARY_OP_TEST_HPP
-#define ELEMENTWISE_TRINARY_OP_TEST_HPP
+#pragma once
 
 #include <sstream>
 
@@ -112,4 +111,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // ELEMENTWISE_TRINARY_OP_TEST_HPP

--- a/test/02_elementwise/elementwise_trinary_op_test_helpers.hpp
+++ b/test/02_elementwise/elementwise_trinary_op_test_helpers.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef ELEMENTWISE_TRINARY_OP_TEST_HELPERS_HPP
-#define ELEMENTWISE_TRINARY_OP_TEST_HELPERS_HPP
+#pragma once
 
 #include <gtest/gtest.h>
 
@@ -76,4 +75,3 @@ auto inline load_config_helper()
                               ::testing::ValuesIn(testParams.operators()));
 }
 
-#endif // ELEMENTWISE_TRINARY_OP_TEST_HELPERS_HPP

--- a/test/03_reduction/reduction_resource.hpp
+++ b/test/03_reduction/reduction_resource.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_RESOURCE_HPP
-#define HIPTENSOR_REDUCTION_RESOURCE_HPP
+#pragma once
 
 #include <memory>
 #include <tuple>
@@ -129,4 +128,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_RESOURCE_HPP

--- a/test/03_reduction/reduction_test.hpp
+++ b/test/03_reduction/reduction_test.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_TEST_HPP
-#define HIPTENSOR_REDUCTION_TEST_HPP
+#pragma once
 
 #include <sstream>
 
@@ -110,4 +109,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_TEST_HPP

--- a/test/03_reduction/reduction_test_helpers.hpp
+++ b/test/03_reduction/reduction_test_helpers.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_TEST_HELPERS_HPP
-#define HIPTENSOR_REDUCTION_TEST_HELPERS_HPP
+#pragma once
 
 #include <gtest/gtest.h>
 
@@ -127,4 +126,3 @@ auto inline load_config_helper()
                               ::testing::ValuesIn(testParams.operators()));
 }
 
-#endif // HIPTENSOR_REDUCTION_TEST_HELPERS_HPP

--- a/test/03_reduction/reduction_test_params.hpp
+++ b/test/03_reduction/reduction_test_params.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_REDUCTION_TEST_PARAMS_HPP
-#define HIPTENSOR_REDUCTION_TEST_PARAMS_HPP
+#pragma once
 
 #include <tuple>
 #include <vector>
@@ -123,4 +122,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_REDUCTION_TEST_PARAMS_HPP

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_TEST_COMMON_HPP
-#define HIPTENSOR_TEST_COMMON_HPP
+#pragma once
 
 #include <hiptensor/internal/hiptensor_utility.hpp>
 
@@ -49,4 +48,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_TEST_COMMON_HPP

--- a/test/device/common.hpp
+++ b/test/device/common.hpp
@@ -24,8 +24,8 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_TEST_CONTRACTION_DEVICE_COMMON_HPP
-#define HIPTENSOR_TEST_CONTRACTION_DEVICE_COMMON_HPP
+#pragma once
+
 #include "../type_traits.hpp"
 
 template <typename T>
@@ -151,4 +151,3 @@ __global__ void compareEqualKernel(DDataType* deviceD,
     }
 }
 
-#endif // HIPTENSOR_TEST_CONTRACTION_DEVICE_COMMON_HPP

--- a/test/hip_resource.hpp
+++ b/test/hip_resource.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_HIPTENSOR_RESOURCE_HPP
-#define HIPTENSOR_HIPTENSOR_RESOURCE_HPP
+#pragma once
 
 #include "common.hpp"
 #include <memory>
@@ -73,4 +72,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_HIPTENSOR_RESOURCE_HPP

--- a/test/hiptensor_length_generation.hpp
+++ b/test/hiptensor_length_generation.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_TEST_LENGTH_GENERATION_HPP
-#define HIPTENSOR_TEST_LENGTH_GENERATION_HPP
+#pragma once
 
 #include "hash.hpp"
 
@@ -402,4 +401,3 @@ namespace hiptensor
 
 } // namespace hiptensor
 
-#endif // HIPTENSOR_TEST_LENGTH_GENERATION_HPP

--- a/test/llvm/command_line_parser.hpp
+++ b/test/llvm/command_line_parser.hpp
@@ -24,12 +24,10 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_COMMAND_LINE_PARSER_IMPL_HPP
-#define HIPTENSOR_COMMAND_LINE_PARSER_IMPL_HPP
+#pragma once
 
 namespace hiptensor
 {
     void parseOptions(int argc, char** argv);
 }
 
-#endif // HIPTENSOR_COMMAND_LINE_PARSER_IMPL_HPP

--- a/test/llvm/yaml_parser.hpp
+++ b/test/llvm/yaml_parser.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_TEST_YAML_PARSER_HPP
-#define HIPTENSOR_TEST_YAML_PARSER_HPP
+#pragma once
 
 #include <optional>
 #include <string>
@@ -42,4 +41,3 @@ namespace hiptensor
     };
 }
 
-#endif // HIPTENSOR_TEST_YAML_PARSER_HPP

--- a/test/llvm/yaml_parser_impl.hpp
+++ b/test/llvm/yaml_parser_impl.hpp
@@ -24,8 +24,7 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_TEST_YAML_PARSER_IMPL_HPP
-#define HIPTENSOR_TEST_YAML_PARSER_IMPL_HPP
+#pragma once
 
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/YAMLParser.h>
@@ -107,4 +106,3 @@ namespace hiptensor
     }
 }
 
-#endif // HIPTENSOR_TEST_YAML_PARSER_IMPL_HPP

--- a/test/type_traits.hpp
+++ b/test/type_traits.hpp
@@ -24,8 +24,8 @@
  *
  *******************************************************************************/
 
-#ifndef HIPTENSOR_TYPE_TRAITS_HPP
-#define HIPTENSOR_TYPE_TRAITS_HPP
+#pragma once
+
 #include <cfloat>
 
 #include <hiptensor/internal/config.hpp>
@@ -76,4 +76,3 @@ namespace std
         return stream << static_cast<float>(val);
     }
 } // namespace std
-#endif // HIPTENSOR_TYPE_TRAITS_HPP


### PR DESCRIPTION
## Motivation

Changing the remaining include files to use `#pragma once`. It makes the compilation faster and avoid naming conflicts and inconsistencies.

## Technical Details

-

## Test Plan

Building the project should not break.

## Test Result

No errors while building the project.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
