### PR TITLE
Bump version to 2.2.0 and update CHANGELOG.md for ROCm 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Full documentation for hipTensor is available at [rocm.docs.amd.com/projects/hip
 
 ### Changed
 
-* Replaced `permutation` with `welementwise` or `elementwise_permute` across folder names, file names, function names, and variable names.
+* Replaced `permutation` with `elementwise` or `elementwise_permute` across folder names, file names, function names, and variable names.
 
 ### Resolved issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for hipTensor is available at [rocm.docs.amd.com/projects/hiptensor](https://rocm.docs.amd.com/projects/hipTensor/en/latest/index.html).
 
-## (Unreleased) hipTensor 2.1.0 for ROCm 7.1.0
+## (Unreleased) hipTensor 2.2.0 for ROCm 7.2.0
 
 ### Added
 
@@ -11,15 +11,30 @@ Full documentation for hipTensor is available at [rocm.docs.amd.com/projects/hip
 * Added `hiptensorHandleReadPlanCacheFromFile` to read a plan cache from a file into a hipTensor handle.
 * Added `simple_contraction_plan_cache` to demonstrate plan cache usages.
 * Added `plan_cache_test` to test the plan cache across various tensor ranks.
+* Added C API headers to enable compatibility with C programs.
+* Added cmake function to allow projects querying about architecture support.
+* Added option to configure memory layout for tests and benchmarks.
+
+### Changed
+
+* Updated C++ standard from C++17 to C++20.
+* Include files `hiptensor/hiptensor.hpp` and `hiptensor/hiptensor_types.hpp` are now deprecated. Use `hiptensor/hiptensor.h` and `hiptensor/hiptensor_types.h` instead.
+* Converted include guards from #ifndef/#define/#endif to #pragma once.
+
+### Resolved issues
+
+* Removed large tensor sizes causing problem in benchmarks.
+
+## hipTensor 2.1.0 for ROCm 7.1.0
+
+### Added
+
 * Added large tensor lengths in benchmark yaml files.
 * Added a new "-l" option to tests for redirecting logs to a file.
-* Added C API headers to enable compatibility with C programs.
 
 ### Changed
 
 * Replaced `permutation` with `welementwise` or `elementwise_permute` across folder names, file names, function names, and variable names.
-* Updated C++ standard from C++17 to C++20.
-* Include files `hiptensor/hiptensor.hpp` and `hiptensor/hiptensor_types.hpp` are now deprecated. Use `hiptensor/hiptensor.h` and `hiptensor/hiptensor_types.h` instead.
 
 ### Resolved issues
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+ # Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal
@@ -207,7 +207,7 @@ if(HIPTENSOR_BUILD_SAMPLES)
 endif()
 
 # Versioning via rocm-cmake
-set ( VERSION_STRING "2.1.0" )
+set ( VERSION_STRING "2.2.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # configure a header file to pass the CMake version settings to the source

--- a/test/00_unit/util_test.cpp
+++ b/test/00_unit/util_test.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -63,7 +63,7 @@ TEST(CheckApiParamsTest, UtilTest)
 
 TEST(hiptensorGetVersionTest, UtilTest)
 {
-    EXPECT_EQ(hiptensorGetVersion(), 2001000);
+    EXPECT_EQ(hiptensorGetVersion(), 2002000);
 }
 
 TEST(logLevelToStringTest, UtilTest)


### PR DESCRIPTION
## Motivation

Bump version to 2.2.0 and update CHANGELOG.md for ROCm 7.2 release

## Technical Details

1. Bump version to 2.2.0
2. Update CHANGELOG.md for ROCm 7.2 release

## Test Plan

run regular tests.

## Test Result

all tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
