### PR TITLE
[hipTensor] fix reduction operations to properly handle permuted modes (#2566)

### DIFF
--- a/library/src/include/util.hpp
+++ b/library/src/include/util.hpp
@@ -26,14 +26,17 @@
 
 #pragma once
 
+#include <algorithm>
+#include <numeric>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
 #include <ck/utility/data_type.hpp>
 #include <ck/utility/tuple.hpp>
 #include <hiptensor/hiptensor.h>
 #include <hiptensor/internal/types.hpp>
 #include <logger.hpp>
-#include <numeric>
-#include <type_traits>
-#include <vector>
 
 namespace hiptensor
 {
@@ -154,6 +157,74 @@ namespace hiptensor
     void convertVectorToCkArray(std::vector<T> const& v, std::array<U, N>& a)
     {
         std::copy_n(v.begin(), N, a.begin());
+    }
+
+    template <typename T>
+    hiptensorStatus_t getSortingIndices(const T*          referenceOrder,
+                                        size_t            referenceSize,
+                                        const T*          elementsToSort,
+                                        size_t            elementsSize,
+                                        std::vector<int>& sortingIndices)
+    {
+        // Create a position map for elements in the reference order
+        std::unordered_map<T, int> elementPosition;
+        for(size_t i = 0; i < referenceSize; ++i)
+        {
+            elementPosition[referenceOrder[i]] = static_cast<int>(i);
+        }
+
+        // Verify all elements in elementsToSort exist in referenceOrder
+        for(size_t i = 0; i < elementsSize; ++i)
+        {
+            if(elementPosition.find(elementsToSort[i]) == elementPosition.end())
+            {
+                return HIPTENSOR_STATUS_INVALID_VALUE;
+            }
+        }
+
+        // Resize the output vector to match input size
+        sortingIndices.resize(elementsSize);
+
+        // Create indices vector [0, 1, 2, ..., elementsSize-1]
+        std::iota(sortingIndices.begin(), sortingIndices.end(), 0);
+
+        // Sort indices based on the order of corresponding elements in referenceOrder
+        std::sort(sortingIndices.begin(),
+                  sortingIndices.end(),
+                  [elementsToSort, &elementPosition](int i, int j) {
+                      return elementPosition[elementsToSort[i]]
+                             < elementPosition[elementsToSort[j]];
+                  });
+
+        return HIPTENSOR_STATUS_SUCCESS;
+    }
+
+    template <typename T>
+    hiptensorStatus_t applySortingIndices(const std::vector<int>& sortingIndices,
+                                          std::vector<T>&         vector)
+    {
+        // Check if sizes match
+        if(sortingIndices.size() != vector.size())
+        {
+            return HIPTENSOR_STATUS_INVALID_VALUE;
+        }
+
+        // Resize output vector
+        std::vector<T> sortedVector = std::vector<T>(vector.size());
+
+        // Apply sorting indices
+        for(size_t i = 0; i < sortingIndices.size(); ++i)
+        {
+            auto index = sortingIndices[i];
+            if(index < 0 || index >= static_cast<int>(vector.size()))
+            {
+                return HIPTENSOR_STATUS_INVALID_VALUE;
+            }
+            sortedVector[i] = vector[index];
+        }
+        vector = sortedVector;
+
+        return HIPTENSOR_STATUS_SUCCESS;
     }
 
     /** @name CK type tuple to hiptensor type tuple transform functions

--- a/library/src/reduction/hiptensor_reduction.cpp
+++ b/library/src/reduction/hiptensor_reduction.cpp
@@ -23,9 +23,11 @@
  * THE SOFTWARE.
  *
  *******************************************************************************/
-#include <hiptensor/hiptensor.h>
 #include <set>
 #include <unordered_set>
+#include <vector>
+
+#include <hiptensor/hiptensor.h>
 
 #include "handle.hpp"
 #include "hip_device.hpp"
@@ -311,6 +313,31 @@ hiptensorStatus_t hiptensorReduce(const hiptensorHandle_t handle,
                                   hipMemcpyDeviceToDevice));
     }
 
+    // CK requires all the modes of the reduced tensors (C/D) to be sorted according to the
+    // non-reduced tensor mode (modeA).
+    //
+    // By permuting the reduced tensor modes and their lengths, if the strides are permuted
+    // following the same order, then it's possible to satisfy CK's requirement without
+    // physically permuting the data.
+    //
+    // For example:
+    //  - A lengths are [3, 5, 8], C/D modes are [2, 1].
+    //  - CK requires sorted modes as [1, 2] for C/D, and the respective lengths [5, 8].
+    //  - Strides of output are generated in this way:
+    //    - output dims are [2, 1]
+    //      => corresponding lengths are [8(2), 5(1)]
+    //      => strides are [5(2), 1(1)]
+    //      => permuted strides are [1(1), 5(2)]
+    //
+    // The code below implements this logic.
+    hiptensorTensorDescriptor sortedDescC    = *descC;
+    std::vector<int>          sortingIndices = {};
+
+    CHECK_HIPTENSOR_ERROR(hiptensor::getSortingIndices(
+        modeA, descA->mLengths.size(), modeC, sortedDescC.mLengths.size(), sortingIndices));
+    CHECK_HIPTENSOR_ERROR(hiptensor::applySortingIndices(sortingIndices, sortedDescC.mLengths));
+    CHECK_HIPTENSOR_ERROR(hiptensor::applySortingIndices(sortingIndices, sortedDescC.mStrides));
+
     for(auto pSolution : solutions)
     {
         using hiptensor::HiptensorOptions;
@@ -330,9 +357,9 @@ hiptensorStatus_t hiptensorReduce(const hiptensorHandle_t handle,
         auto [isSupported, time] = (*pSolution)(descA->mLengths,
                                                 descA->mStrides,
                                                 {modeA, modeA + descA->mLengths.size()},
-                                                descC->mLengths,
-                                                descC->mStrides,
-                                                {modeC, modeC + descC->mLengths.size()},
+                                                sortedDescC.mLengths,
+                                                sortedDescC.mStrides,
+                                                {modeC, modeC + sortedDescC.mLengths.size()},
                                                 opA,
                                                 opC,
                                                 alphaValue,

--- a/library/src/reduction/reduction_cpu_reference.cpp
+++ b/library/src/reduction/reduction_cpu_reference.cpp
@@ -24,8 +24,10 @@
  *
  *******************************************************************************/
 
-#include "reduction_cpu_reference.hpp"
+#include <vector>
+
 #include "../elementwise/elementwise_cpu_reference.hpp"
+#include "reduction_cpu_reference.hpp"
 #include "reduction_cpu_reference_impl.hpp"
 #include "reduction_cpu_reference_instances.hpp"
 
@@ -114,6 +116,31 @@ hiptensorStatus_t hiptensorReductionReference(const void*                       
                                   hipMemcpyHostToHost));
     }
 
+    // CK requires all the modes of the reduced tensors (C/D) to be sorted according to the
+    // non-reduced tensor mode (modeA).
+    //
+    // By permuting the reduced tensor modes and their lengths, if the strides are permuted
+    // following the same order, then it's possible to satisfy CK's requirement without
+    // physically permuting the data.
+    //
+    // For example:
+    //  - A lengths are [3, 5, 8], C/D modes are [2, 1].
+    //  - CK requires sorted modes as [1, 2] for C/D, and the respective lengths [5, 8].
+    //  - Strides of output are generated in this way:
+    //    - output dims are [2, 1]
+    //      => corresponding lengths are [8(2), 5(1)]
+    //      => strides are [5(2), 1(1)]
+    //      => permuted strides are [1(1), 5(2)]
+    //
+    // The code below implements this logic.
+    hiptensorTensorDescriptor sortedDescC    = *descC;
+    std::vector<int>          sortingIndices = {};
+
+    CHECK_HIPTENSOR_ERROR(hiptensor::getSortingIndices(
+        modeA, descA->mLengths.size(), modeC, sortedDescC.mLengths.size(), sortingIndices));
+    CHECK_HIPTENSOR_ERROR(hiptensor::applySortingIndices(sortingIndices, sortedDescC.mLengths));
+    CHECK_HIPTENSOR_ERROR(hiptensor::applySortingIndices(sortingIndices, sortedDescC.mStrides));
+
     for(auto [_, pSolution] : solutionQ.solutions())
     {
         // Perform reduction with timing if LOG_LEVEL_PERF_TRACE
@@ -121,9 +148,9 @@ hiptensorStatus_t hiptensorReductionReference(const void*                       
         auto [isSupported, time] = (*pSolution)(descA->mLengths,
                                                 descA->mStrides,
                                                 {modeA, modeA + descA->mLengths.size()},
-                                                descC->mLengths,
-                                                descC->mStrides,
-                                                {modeC, modeC + descC->mLengths.size()},
+                                                sortedDescC.mLengths,
+                                                sortedDescC.mStrides,
+                                                {modeC, modeC + sortedDescC.mLengths.size()},
                                                 opA,
                                                 opC,
                                                 alphaD,

--- a/test/03_reduction/reduction_test.cpp
+++ b/test/03_reduction/reduction_test.cpp
@@ -359,30 +359,12 @@ namespace hiptensor
             int nmodeC = modeC.size();
             int nmodeD = nmodeC;
 
-            // Requirement of lengths and strides of output
-            //
-            // For example, input lengths are [3, 5, 8], output dims are [2, 1]
-            //
-            // CK requires that lengths of output are [5, 8], i.e. lengths of sorted output dims
-            //
-            // Strides of output are generated in this way:
-            //   output dims are [2, 1]
-            //     ==> corresponding lengths are [8(2), 5(1)]
-            //     ==> strides are [5(2), 1(1)]
-            //     ==> sorted strides are [1(1), 5(2)] // sort by dim
-            //
-            //  strides of output are [1, 5]
-            std::vector<int> sortedOutputDims(outputDims.cbegin(), outputDims.cend());
-            std::sort(sortedOutputDims.begin(), sortedOutputDims.end());
-
             std::vector<int64_t> extentA(lengths.cbegin(), lengths.cend());
-            std::vector<int64_t> extentC(sortedOutputDims.cbegin(), sortedOutputDims.cend());
-            std::transform(extentC.cbegin(), extentC.cend(), extentC.begin(), [&lengths](auto dim) {
-                return lengths[dim];
-            });
-            std::vector<int64_t> extentD(extentC);
-
-            auto& options = HiptensorOptions::instance();
+            std::vector<int64_t> extentCD(outputDims.cbegin(), outputDims.cend());
+            std::transform(extentCD.cbegin(),
+                           extentCD.cend(),
+                           extentCD.begin(),
+                           [&lengths](auto dim) { return lengths[dim]; });
 
             std::vector<int64_t> stridesA
                 = memoryLayout == HIPTENSOR_MEMORY_LAYOUT_DEFAULT
@@ -390,36 +372,11 @@ namespace hiptensor
                       : hiptensor::stridesFromLengths(
                             extentA, memoryLayout == HIPTENSOR_MEMORY_LAYOUT_COLUMN_MAJOR);
 
-            std::vector<int64_t> strideD
-                = hiptensor::stridesFromLengths(extentD, options->isColMajorStrides());
-            if(!std::equal(outputDims.cbegin(), outputDims.cend(), sortedOutputDims.cbegin()))
-            {
-                std::unordered_map<int, int64_t> dimToStride;
-                int64_t                          stride = 1;
-
-                if(!options->isColMajorStrides())
-                {
-                    for(auto it = outputDims.crbegin(); it != outputDims.crend(); ++it)
-                    {
-                        dimToStride[*it] = stride;
-                        stride *= lengths[*it];
-                    }
-                }
-                else
-                {
-                    for(auto it = outputDims.cbegin(); it != outputDims.cend(); ++it)
-                    {
-                        dimToStride[*it] = stride;
-                        stride *= lengths[*it];
-                    }
-                }
-
-                std::transform(sortedOutputDims.cbegin(),
-                               sortedOutputDims.cend(),
-                               strideD.begin(),
-                               [&dimToStride](uint64_t dim) { return dimToStride[dim]; });
-            }
-            std::vector<int64_t> strideC = strideD;
+            std::vector<int64_t> stridesCD
+                = memoryLayout == HIPTENSOR_MEMORY_LAYOUT_DEFAULT
+                      ? std::vector<int64_t>{}
+                      : hiptensor::stridesFromLengths(
+                            extentCD, memoryLayout == HIPTENSOR_MEMORY_LAYOUT_COLUMN_MAJOR);
 
             hiptensorStatus_t err;
             hiptensorHandle_t handle;
@@ -438,12 +395,24 @@ namespace hiptensor
                                                 0));
 
             hiptensorTensorDescriptor_t descC = nullptr;
-            CHECK_HIPTENSOR_ERROR(hiptensorCreateTensorDescriptor(
-                handle, &descC, nmodeC, extentC.data(), strideC.data(), acDataType, 0));
+            CHECK_HIPTENSOR_ERROR(
+                hiptensorCreateTensorDescriptor(handle,
+                                                &descC,
+                                                nmodeC,
+                                                extentCD.data(),
+                                                stridesCD.data() ? nullptr : stridesCD.data(),
+                                                acDataType,
+                                                0));
 
             hiptensorTensorDescriptor_t descD = nullptr;
-            CHECK_HIPTENSOR_ERROR(hiptensorCreateTensorDescriptor(
-                handle, &descD, nmodeD, extentD.data(), strideD.data(), acDataType, 0));
+            CHECK_HIPTENSOR_ERROR(
+                hiptensorCreateTensorDescriptor(handle,
+                                                &descD,
+                                                nmodeD,
+                                                extentCD.data(),
+                                                stridesCD.data() ? nullptr : stridesCD.data(),
+                                                acDataType,
+                                                0));
 
             hiptensorComputeDescriptor_t const descCompute = convertToComputeType(dataTypes[1]);
             hiptensorOperationDescriptor_t     desc;
@@ -519,8 +488,8 @@ namespace hiptensor
                                            hiptensorDataTypeSize(acDataType),
                                            std::multiplies<size_t>());
 
-            size_t sizeCD = std::accumulate(extentC.begin(),
-                                            extentC.end(),
+            size_t sizeCD = std::accumulate(extentCD.begin(),
+                                            extentCD.end(),
                                             hiptensorDataTypeSize(acDataType),
                                             std::multiplies<size_t>());
 


### PR DESCRIPTION
Manually applying missing patch from rocm-libraries to stand-alone repo.